### PR TITLE
fix: disable MFE minification to fix Module Federation React sharing

### DIFF
--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/vite.config.ts
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   },
   build: {
     target: "chrome89",
+    minify: false,
   },
   test: {
     exclude: ["e2e/**", "node_modules/**"],


### PR DESCRIPTION
## Problem
When the frontend MFE is built with esbuild minification (default), the `react-jsx-runtime` production code gets mangled variables that reference React (`$d`). Module Federation replaces the React import with a shared module, but the minified variable reference breaks, causing `ReferenceError: $d is not defined` at runtime.

## Fix
Set `build.minify: false` in the frontend_app vite.config.ts template. This preserves variable names so Module Federation's shared React module works correctly.

Bundle size increases slightly (~30%) but this is acceptable for an MFE loaded on demand.

## Verified
- Shell renders correctly with auth (Clerk)
- MFE dashboard loads inside shell with stats cards, tables
- All navigation works (Dashboard, My Dogs, Add Dog, Poop Log, Log Poop)
- API calls work through gateway