### PR TITLE
fix: null-safe rendering in list pages

### DIFF
--- a/src/apps_generator/cli/generators/pages.py
+++ b/src/apps_generator/cli/generators/pages.py
@@ -162,11 +162,15 @@ def write_list_page(
         tag = "TableCell" if ui else 'td className="p-2"'
         close_tag = "TableCell" if ui else "td"
         if ft == "decimal":
-            cols.append(f"              <{tag}>${{p.{fname}.toFixed(2)}}</{close_tag}>")
+            cols.append(f'              <{tag}>{{p.{fname} != null ? `${{p.{fname}.toFixed(2)}}` : "—"}}</{close_tag}>')
         elif ft == "boolean":
             cols.append(f'              <{tag}>{{p.{fname} ? "Yes" : "No"}}</{close_tag}>')
+        elif ft in ("date", "datetime"):
+            cols.append(
+                f'              <{tag}>{{p.{fname} ? new Date(p.{fname}).toLocaleDateString() : "—"}}</{close_tag}>'
+            )
         else:
-            cols.append(f"              <{tag}>{{p.{fname}}}</{close_tag}>")
+            cols.append(f'              <{tag}>{{p.{fname} ?? "—"}}</{close_tag}>')
     cells = "\n".join(cols)
 
     # Button element


### PR DESCRIPTION
Closes #10

Null decimal fields crash with `TypeError: Cannot read properties of null (reading 'toFixed')`. Now all field types are null-safe:
- Decimal: shows "—" when null
- Date/datetime: formats with `toLocaleDateString()` or shows "—"
- String: uses `??` operator to show "—" for null