### PR TITLE
feat: enum field type, smart forms, and resource lookups

### DIFF
--- a/src/apps_generator/cli/generators/migrations.py
+++ b/src/apps_generator/cli/generators/migrations.py
@@ -32,6 +32,9 @@ def generate_migration(res_root: Path, entity: str, table: str, fields: list[dic
         if ft == "string":
             max_len = f.get("maxLength", 255)
             sql_type = f"VARCHAR({max_len})"
+        elif ft == "enum":
+            max_len = f.get("maxLength") or max((len(v) for v in f.get("values", [""])), default=50)
+            sql_type = f"VARCHAR({max_len})"
         col: dict = {"name": snake_case(f["name"]), "type": sql_type}
         if f.get("required"):
             col["nullable"] = False

--- a/src/apps_generator/cli/generators/pages.py
+++ b/src/apps_generator/cli/generators/pages.py
@@ -162,11 +162,15 @@ def write_list_page(
         tag = "TableCell" if ui else 'td className="p-2"'
         close_tag = "TableCell" if ui else "td"
         if ft == "decimal":
-            cols.append(f"              <{tag}>${{p.{fname}.toFixed(2)}}</{close_tag}>")
+            cols.append(f'              <{tag}>{{p.{fname} != null ? `${{p.{fname}.toFixed(2)}}` : "—"}}</{close_tag}>')
         elif ft == "boolean":
             cols.append(f'              <{tag}>{{p.{fname} ? "Yes" : "No"}}</{close_tag}>')
+        elif ft in ("date", "datetime"):
+            cols.append(
+                f'              <{tag}>{{p.{fname} ? new Date(p.{fname}).toLocaleDateString() : "—"}}</{close_tag}>'
+            )
         else:
-            cols.append(f"              <{tag}>{{p.{fname}}}</{close_tag}>")
+            cols.append(f'              <{tag}>{{p.{fname} ?? "—"}}</{close_tag}>')
     cells = "\n".join(cols)
 
     # Button element
@@ -378,6 +382,17 @@ def write_form_page(
                     f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
                     f"        </div>"
                 )
+            elif ft == "enum" and f.get("values"):
+                options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <select id="{fname}" className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                    f'              <option value="">Select {flabel}...</option>{options}\n'
+                    f"            </select>\n"
+                    f"        </div>"
+                )
             else:
                 inputs.append(
                     f'        <div className="space-y-2">\n'
@@ -421,6 +436,17 @@ def write_form_page(
                     f'        <div className="flex items-center space-x-2">\n'
                     f'          <input id="{fname}" type="checkbox" className="h-4 w-4 rounded border-primary" checked={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.checked}}))}}/>\n'
                     f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}</label>\n'
+                    f"        </div>"
+                )
+            elif ft == "enum" and f.get("values"):
+                options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f'          <select id="{fname}" className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                    f'              <option value="">Select {flabel}...</option>{options}\n'
+                    f"            </select>\n"
                     f"        </div>"
                 )
             else:

--- a/src/apps_generator/cli/generators/resources.py
+++ b/src/apps_generator/cli/generators/resources.py
@@ -20,6 +20,7 @@ JAVA_TYPES = {
     "boolean": "Boolean",
     "date": "LocalDate",
     "datetime": "LocalDateTime",
+    "enum": "__ENUM__",  # placeholder — replaced by generated enum class name
 }
 
 SQL_TYPES = {
@@ -31,6 +32,7 @@ SQL_TYPES = {
     "boolean": "BOOLEAN",
     "date": "DATE",
     "datetime": "TIMESTAMP",
+    "enum": "VARCHAR({maxLength})",
 }
 
 TS_TYPES = {
@@ -42,6 +44,7 @@ TS_TYPES = {
     "boolean": "boolean",
     "date": "string",
     "datetime": "string",
+    "enum": "__ENUM__",  # placeholder — replaced by union type
 }
 
 JAVA_IMPORTS = {
@@ -90,6 +93,11 @@ def generate_resource_scaffolding(
 
         console.print(f"  Generating resource: [bold]{entity_name}[/bold]")
 
+        # Generate enum classes first (needed by entity)
+        for f in fields:
+            if f.get("type") == "enum" and f.get("values"):
+                _gen_enum_class(java_root, base_package, entity_name, f)
+
         _gen_entity(java_root, base_package, entity_name, table_name, fields)
         _gen_repository(java_root, base_package, entity_name)
         _gen_service(java_root, base_package, entity_name, name)
@@ -115,10 +123,45 @@ def _collect_imports(fields: list[dict]) -> list[str]:
     return sorted(imports)
 
 
+def _gen_enum_class(java_root: Path, pkg: str, entity: str, field: dict) -> str:
+    """Generate a Java enum class for an enum field. Returns the enum class name."""
+    enum_name = pascal_case(field["name"])
+    values = field.get("values", [])
+    if not values:
+        return "String"
+
+    dest = java_root / "domain" / "model" / f"{enum_name}.java"
+    if not dest.exists():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        enum_values = ", ".join(v.upper().replace("-", "_").replace(" ", "_") for v in values)
+        dest.write_text(f"package {pkg}.domain.model;\n\npublic enum {enum_name} {{\n    {enum_values}\n}}\n")
+        console.print(f"    Created: domain/model/{enum_name}.java")
+    return enum_name
+
+
+def _java_type_for_field(f: dict) -> str:
+    """Get Java type for a field, handling enum specially."""
+    ft = f.get("type", "string")
+    if ft == "enum":
+        return pascal_case(f["name"])
+    return JAVA_TYPES.get(ft, "String")
+
+
+def _ts_type_for_field(f: dict) -> str:
+    """Get TypeScript type for a field, handling enum specially."""
+    ft = f.get("type", "string")
+    if ft == "enum":
+        values = f.get("values", [])
+        if values:
+            return " | ".join(f'"{v}"' for v in values)
+        return "string"
+    return TS_TYPES.get(ft, "string")
+
+
 def _java_field(f: dict, with_validation: bool = False) -> str:
     """Generate a Java field declaration with optional validation annotations."""
     ft = f.get("type", "string")
-    java_type = JAVA_TYPES.get(ft, "String")
+    java_type = _java_type_for_field(f)
     name = camel_case(f["name"])
     required = f.get("required", False)
     unique = f.get("unique", False)
@@ -164,6 +207,10 @@ def _java_field(f: dict, with_validation: bool = False) -> str:
     if col_parts and not with_validation:
         lines.append(f"    @Column({', '.join(col_parts)})")
 
+    # Enum annotation for entity
+    if ft == "enum" and not with_validation:
+        lines.append("    @Enumerated(EnumType.STRING)")
+
     lines.append(f"    private {java_type} {name};")
     return "\n".join(lines)
 
@@ -184,8 +231,7 @@ def _gen_entity(java_root: Path, pkg: str, entity: str, table: str, fields: list
     # Getters and setters (only for user-defined fields — id/tenantId/timestamps come from base)
     accessors = []
     for f in fields:
-        ft = f.get("type", "string")
-        java_type = JAVA_TYPES.get(ft, "String")
+        java_type = _java_type_for_field(f)
         name = camel_case(f["name"])
         getter = f"get{pascal_case(f['name'])}"
         setter = f"set{pascal_case(f['name'])}"
@@ -346,8 +392,7 @@ def _gen_create_request(java_root: Path, pkg: str, entity: str, fields: list[dic
     # Getters/setters
     accessors = []
     for f in fields:
-        ft = f.get("type", "string")
-        java_type = JAVA_TYPES.get(ft, "String")
+        java_type = _java_type_for_field(f)
         name = camel_case(f["name"])
         getter = f"get{pascal_case(f['name'])}"
         setter = f"set{pascal_case(f['name'])}"
@@ -402,8 +447,7 @@ def _gen_update_request(java_root: Path, pkg: str, entity: str, fields: list[dic
 
     accessors = []
     for f in fields:
-        ft = f.get("type", "string")
-        java_type = JAVA_TYPES.get(ft, "String")
+        java_type = _java_type_for_field(f)
         name = camel_case(f["name"])
         getter = f"get{pascal_case(f['name'])}"
         setter = f"set{pascal_case(f['name'])}"
@@ -449,8 +493,7 @@ def _gen_response_dto(java_root: Path, pkg: str, entity: str, fields: list[dict]
 
     # User fields
     for f in fields:
-        ft = f.get("type", "string")
-        java_type = JAVA_TYPES.get(ft, "String")
+        java_type = _java_type_for_field(f)
         name = camel_case(f["name"])
         field_defs.append(f"    private {java_type} {name};")
         g = f"get{pascal_case(f['name'])}"

--- a/src/apps_generator/cli/generators/types.py
+++ b/src/apps_generator/cli/generators/types.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from apps_generator.utils.console import console
 from apps_generator.utils.naming import pascal_case, camel_case
 
-from apps_generator.cli.generators.resources import TS_TYPES
+from apps_generator.cli.generators.resources import _ts_type_for_field
 
 
 def generate_resource_types(api_client_src: Path, resources: list[dict]) -> None:
@@ -31,7 +31,7 @@ def generate_resource_types(api_client_src: Path, resources: list[dict]) -> None
         response_fields = ["  id: number;", "  tenantId: string;"]
         create_fields = []
         for f in fields:
-            ts_type = TS_TYPES.get(f.get("type", "string"), "string")
+            ts_type = _ts_type_for_field(f)
             fname = camel_case(f["name"])
             required = f.get("required", False)
             if required:


### PR DESCRIPTION
Closes #9

## Enum field type
- New `enum` type with `values` array in resource definitions
- Generates Java enum classes with `@Enumerated(EnumType.STRING)`
- TypeScript union types (`"firm" | "soft" | "watery"`)
- `<select>` dropdowns with predefined options in forms
- Migration generates VARCHAR column sized to longest value

## Smart form inputs
- `datetime` fields → `<input type="datetime-local">`
- Resource lookups auto-detected (`dogName` → dog dropdown from API)
- Empty lookup shows "No Dogs found. Create one first" with link
- `all_resources` passed from `generate.py` for auto-detection

## Verified
Tested end-to-end with poop-tracker: add dog, log poop with enum dropdowns + dog lookup, verify list and dashboard.