### PR TITLE
feat(ui-kit): add 12 shadcn components for Phase 0 of page-type catalog

### DIFF
--- a/src/apps_generator/cli/generators/linking.py
+++ b/src/apps_generator/cli/generators/linking.py
@@ -191,11 +191,35 @@ export default {{
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         }},
+        sidebar: {{
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        }},
       }},
       borderRadius: {{
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+      }},
+      keyframes: {{
+        "accordion-down": {{
+          from: {{ height: "0" }},
+          to: {{ height: "var(--radix-accordion-content-height)" }},
+        }},
+        "accordion-up": {{
+          from: {{ height: "var(--radix-accordion-content-height)" }},
+          to: {{ height: "0" }},
+        }},
+      }},
+      animation: {{
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
       }},
     }},
   }},
@@ -223,6 +247,32 @@ export default {{
     "duration-300", "ease-in-out",
     "translate-x-0", "-translate-x-full", "translate-y-full", "-translate-y-full",
     "sr-only",
+    // popover, calendar, date-picker, combobox, command
+    "w-72", "bg-popover", "text-popover-foreground", "shadow-md", "outline-none",
+    "data-[state=open]:animate-in", "data-[state=closed]:animate-out",
+    "data-[state=closed]:fade-out-0", "data-[state=open]:fade-in-0",
+    "data-[state=closed]:zoom-out-95", "data-[state=open]:zoom-in-95",
+    "w-auto", "p-0", "p-3", "max-h-[300px]", "overflow-y-auto", "overflow-x-hidden",
+    "justify-start", "font-normal", "text-center", "py-6",
+    // form
+    "space-y-2", "text-destructive",
+    // radio-group
+    "aspect-square", "h-4", "w-4", "border-primary", "text-primary",
+    "focus:outline-none", "focus-visible:ring-2", "h-2.5", "w-2.5", "fill-current",
+    // alert-dialog
+    "grid", "max-w-lg", "bg-background", "p-6", "shadow-lg", "duration-200",
+    "sm:rounded-lg",
+    // collapsible, accordion
+    "animate-accordion-down", "animate-accordion-up",
+    "data-[state=open]:rotate-180", "transition-transform",
+    // sidebar
+    "bg-sidebar", "text-sidebar-foreground", "border-sidebar-border", "ring-sidebar-ring",
+    "hover:bg-sidebar-accent", "hover:text-sidebar-accent-foreground",
+    "data-[active=true]:bg-sidebar-accent", "data-[active=true]:text-sidebar-accent-foreground",
+    "min-h-svh", "peer/menu-button", "group/menu-item",
+    // navigation-menu
+    "group", "data-[active]:bg-accent/50", "data-[state=open]:bg-accent/50",
+    "origin-top-center", "md:w-auto",
   ],
   plugins: [],
 }};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/package.json
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/package.json
@@ -33,17 +33,29 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
+    "@radix-ui/react-accordion": "^1.2.0",
+    "@radix-ui/react-alert-dialog": "^1.1.0",
+    "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-navigation-menu": "^1.2.0",
+    "@radix-ui/react-popover": "^1.1.0",
+    "@radix-ui/react-radio-group": "^1.2.0",
     "@radix-ui/react-select": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "cmdk": "^1.0.0",
+    "date-fns": "^3.6.0",
     "lucide-react": "^0.400.0",
+    "react-day-picker": "^9.0.0",
+    "react-hook-form": "^7.53.0",
     "tailwind-merge": "^2.4.0",
     "recharts": "^2.12.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "~8.6.0",

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/accordion.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/accordion.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/alert-dialog.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "./button";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/calendar.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/calendar.tsx
@@ -1,4 +1,3 @@
-{% raw %}
 "use client";
 
 import * as React from "react";
@@ -20,7 +19,7 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
-      classNames={{
+      classNames={ {
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
         month_caption: "flex justify-center pt-1 relative items-center",
@@ -55,15 +54,15 @@ function Calendar({
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
         hidden: "invisible",
         ...classNames,
-      }}
-      components={{
+      } }
+      components={ {
         Chevron: ({ orientation, ...iconProps }) =>
           orientation === "right" ? (
             <ChevronRight className="h-4 w-4" {...iconProps} />
           ) : (
             <ChevronLeft className="h-4 w-4" {...iconProps} />
           ),
-      }}
+      } }
       {...props}
     />
   );
@@ -71,4 +70,3 @@ function Calendar({
 Calendar.displayName = "Calendar";
 
 export { Calendar };
-{% endraw %}

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/calendar.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/calendar.tsx
@@ -1,0 +1,74 @@
+{% raw %}
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "./button";
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        month_caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        button_previous: cn(
+          buttonVariants({ variant: "outline" }),
+          "absolute left-1 top-1 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "absolute right-1 top-1 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        month_grid: "w-full border-collapse space-y-1",
+        weekdays: "flex",
+        weekday:
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+        week: "flex w-full mt-2",
+        day: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        day_button: cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+        ),
+        range_end: "day-range-end",
+        selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        today: "bg-accent text-accent-foreground",
+        outside:
+          "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        disabled: "text-muted-foreground opacity-50",
+        range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, ...iconProps }) =>
+          orientation === "right" ? (
+            <ChevronRight className="h-4 w-4" {...iconProps} />
+          ) : (
+            <ChevronLeft className="h-4 w-4" {...iconProps} />
+          ),
+      }}
+      {...props}
+    />
+  );
+}
+Calendar.displayName = "Calendar";
+
+export { Calendar };
+{% endraw %}

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/chart.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/chart.tsx
@@ -1,4 +1,3 @@
-{% raw %}
 import * as React from "react";
 import { ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { cn } from "@/lib/utils";
@@ -23,21 +22,20 @@ interface ChartContainerProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const ChartContainer = React.forwardRef<HTMLDivElement, ChartContainerProps>(
   ({ config, className, children, ...props }, ref) => {
-    // Inject chart colors as CSS variables
-    const style: React.CSSProperties = {};
+    // Inject chart colors as CSS variables. Build the map as a plain string
+    // record so arbitrary custom-property keys (``--color-<field>``) type-check,
+    // then cast to CSSProperties when passing to `style` — React/DOM accept
+    // unknown custom properties at runtime.
+    const cssVars: Record<string, string> = {};
     Object.entries(config).forEach(([key, value], index) => {
-      if (value.color) {
-        style[`--color-${key}` as string] = value.color;
-      } else {
-        style[`--color-${key}` as string] = `hsl(var(--chart-${index + 1}))`;
-      }
+      cssVars[`--color-${key}`] = value.color ?? `hsl(var(--chart-${index + 1}))`;
     });
 
     return (
       <div
         ref={ref}
         className={cn("flex aspect-video justify-center text-xs", className)}
-        style={style}
+        style={cssVars as React.CSSProperties}
         {...props}
       >
         <ResponsiveContainer width="100%" height="100%">
@@ -93,19 +91,19 @@ function ChartTooltipContent({
               {indicator === "dot" && (
                 <span
                   className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: color }}
+                  style={ { backgroundColor: color } }
                 />
               )}
               {indicator === "line" && (
                 <span
                   className="h-0.5 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: color }}
+                  style={ { backgroundColor: color } }
                 />
               )}
               {indicator === "dashed" && (
                 <span
                   className="h-0.5 w-3 shrink-0 rounded-full border-b-2 border-dashed"
-                  style={{ borderColor: color }}
+                  style={ { borderColor: color } }
                 />
               )}
               <span className="text-muted-foreground">{displayLabel}</span>
@@ -149,7 +147,7 @@ function ChartLegendContent({ payload, config }: ChartLegendContentProps) {
           <div key={index} className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <span
               className="h-2.5 w-2.5 shrink-0 rounded-full"
-              style={{ backgroundColor: entry.color }}
+              style={ { backgroundColor: entry.color } }
             />
             {label}
           </div>
@@ -159,7 +157,13 @@ function ChartLegendContent({ payload, config }: ChartLegendContentProps) {
   );
 }
 
-function ChartLegend(props: React.ComponentProps<typeof Legend>) {
+// Recharts' `Legend` class exposes a `LegacyRef<ReactElement>` typing that
+// is not compatible with `LegacyRef<Legend>` when we spread the whole
+// `ComponentProps` bag (it's an open generics bug in @types/recharts v2).
+// We don't forward a ref here, so strip it before spreading.
+type ChartLegendProps = Omit<React.ComponentProps<typeof Legend>, "ref">;
+
+function ChartLegend(props: ChartLegendProps) {
   return <Legend content={<ChartLegendContent />} {...props} />;
 }
 
@@ -170,4 +174,3 @@ export {
   ChartLegend,
   ChartLegendContent,
 };
-{% endraw %}

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/collapsible.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+const Collapsible = CollapsiblePrimitive.Root;
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/combobox.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/combobox.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "./button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./command";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface ComboboxProps {
+  options: ComboboxOption[];
+  value?: string;
+  onChange?: (value: string | undefined) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  name?: string;
+}
+
+/**
+ * Accessible typeahead select built from Command + Popover.
+ *
+ * This replaces the native ``<select>`` dropdown for resource-lookup fields in
+ * generated forms — it stays usable as soon as the option list gets long.
+ */
+const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
+  (
+    {
+      options,
+      value,
+      onChange,
+      placeholder = "Select...",
+      searchPlaceholder = "Search...",
+      emptyText = "No results.",
+      disabled,
+      className,
+      id,
+      name,
+    },
+    ref
+  ) => {
+    const [open, setOpen] = React.useState(false);
+    const selected = options.find((o) => o.value === value);
+
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={ref}
+            id={id}
+            name={name}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className={cn("w-full justify-between font-normal", className)}
+          >
+            {selected ? selected.label : <span className="text-muted-foreground">{placeholder}</span>}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+          <Command>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyText}</CommandEmpty>
+              <CommandGroup>
+                {options.map((opt) => (
+                  <CommandItem
+                    key={opt.value}
+                    value={opt.label}
+                    disabled={opt.disabled}
+                    onSelect={() => {
+                      onChange?.(opt.value === value ? undefined : opt.value);
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        opt.value === value ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    {opt.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+);
+Combobox.displayName = "Combobox";
+
+export { Combobox };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/command.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/command.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent } from "./dialog";
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+interface CommandDialogProps extends React.ComponentProps<typeof Dialog> {}
+
+const CommandDialog = ({ children, ...props }: CommandDialogProps) => (
+  <Dialog {...props}>
+    <DialogContent className="overflow-hidden p-0">
+      <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        {children}
+      </Command>
+    </DialogContent>
+  </Dialog>
+);
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm"
+    {...props}
+  />
+));
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span
+    className={cn(
+      "ml-auto text-xs tracking-widest text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+);
+CommandShortcut.displayName = "CommandShortcut";
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/date-picker.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/date-picker.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import * as React from "react";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "./button";
+import { Calendar } from "./calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+export interface DatePickerProps {
+  value?: Date;
+  onChange?: (date: Date | undefined) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /** Format string for the display label. See date-fns format tokens. */
+  displayFormat?: string;
+  id?: string;
+  name?: string;
+}
+
+/**
+ * Controlled date picker built from Calendar + Popover.
+ *
+ * Plain-JS date value to keep the API simple; integrate with react-hook-form
+ * via <Controller>. Requires `date-fns` transitively through react-day-picker.
+ */
+const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
+  (
+    {
+      value,
+      onChange,
+      placeholder = "Pick a date",
+      disabled,
+      className,
+      displayFormat = "PPP",
+      id,
+      name,
+    },
+    ref
+  ) => {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={ref}
+            id={id}
+            name={name}
+            variant="outline"
+            disabled={disabled}
+            className={cn(
+              "w-full justify-start text-left font-normal",
+              !value && "text-muted-foreground",
+              className
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {value ? format(value, displayFormat) : <span>{placeholder}</span>}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={value}
+            onSelect={(d) => {
+              onChange?.(d ?? undefined);
+              if (d) setOpen(false);
+            }}
+            autoFocus
+          />
+        </PopoverContent>
+      </Popover>
+    );
+  }
+);
+DatePicker.displayName = "DatePicker";
+
+export { DatePicker };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/form.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/form.tsx
@@ -1,4 +1,3 @@
-{% raw %}
 "use client";
 
 import * as React from "react";
@@ -49,7 +48,7 @@ const FormField = <
   ...props
 }: ControllerProps<TFieldValues, TName>) => {
   return (
-    <FormFieldContext.Provider value={{ name: props.name }}>
+    <FormFieldContext.Provider value={ { name: props.name } }>
       <Controller {...props} />
     </FormFieldContext.Provider>
   );
@@ -92,7 +91,7 @@ const FormItem = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const id = React.useId();
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={ { id } }>
       <div ref={ref} className={cn("space-y-2", className)} {...props} />
     </FormItemContext.Provider>
   );
@@ -180,4 +179,3 @@ export {
   FormMessage,
   useFormField,
 };
-{% endraw %}

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/form.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/form.tsx
@@ -1,0 +1,183 @@
+{% raw %}
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "./label";
+
+/**
+ * shadcn-style react-hook-form wrapper. Compose via:
+ *
+ *   <Form {...form}>
+ *     <FormField name="email" render={({ field }) => (
+ *       <FormItem>
+ *         <FormLabel>Email</FormLabel>
+ *         <FormControl><Input {...field} /></FormControl>
+ *         <FormMessage />
+ *       </FormItem>
+ *     )} />
+ *   </Form>
+ */
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+);
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId();
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  );
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField();
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
+  if (!body) return null;
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+};
+{% endraw %}

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/navigation-menu.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const NavigationMenu = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <NavigationMenuViewport />
+  </NavigationMenuPrimitive.Root>
+));
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
+
+const NavigationMenuList = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    ref={ref}
+    className={cn(
+      "group flex flex-1 list-none items-center justify-center space-x-1",
+      className
+    )}
+    {...props}
+  />
+));
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item;
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+);
+
+const NavigationMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Trigger
+    ref={ref}
+    className={cn(navigationMenuTriggerStyle(), "group", className)}
+    {...props}
+  >
+    {children}{" "}
+    <ChevronDown
+      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+      aria-hidden="true"
+    />
+  </NavigationMenuPrimitive.Trigger>
+));
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
+
+const NavigationMenuContent = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Content
+    ref={ref}
+    className={cn(
+      "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto",
+      className
+    )}
+    {...props}
+  />
+));
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
+
+const NavigationMenuLink = NavigationMenuPrimitive.Link;
+
+const NavigationMenuViewport = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <div className={cn("absolute left-0 top-full flex justify-center")}>
+    <NavigationMenuPrimitive.Viewport
+      className={cn(
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  </div>
+));
+NavigationMenuViewport.displayName = NavigationMenuPrimitive.Viewport.displayName;
+
+const NavigationMenuIndicator = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Indicator
+    ref={ref}
+    className={cn(
+      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
+      className
+    )}
+    {...props}
+  >
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+  </NavigationMenuPrimitive.Indicator>
+));
+NavigationMenuIndicator.displayName = NavigationMenuPrimitive.Indicator.displayName;
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+  navigationMenuTriggerStyle,
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/popover.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/popover.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/radio-group.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/radio-group.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Root
+    ref={ref}
+    className={cn("grid gap-2", className)}
+    {...props}
+  />
+));
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <Circle className="h-2.5 w-2.5 fill-current text-current" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/sidebar.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/sidebar.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { PanelLeft } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "./button";
+
+/**
+ * Pragmatic shadcn-style Sidebar: provider + collapsible sidebar + menu
+ * primitives. Supports collapsed/expanded state with a trigger. Keeps
+ * platform-shell nav concerns covered without the full shadcn block's
+ * cookie persistence and offcanvas-mobile behaviour — those can be added
+ * later in platform-shell itself.
+ */
+
+type SidebarContextValue = {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  toggle: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextValue | null>(null);
+
+export function useSidebar(): SidebarContextValue {
+  const ctx = React.useContext(SidebarContext);
+  if (!ctx) throw new Error("useSidebar must be used within <SidebarProvider>");
+  return ctx;
+}
+
+interface SidebarProviderProps extends React.HTMLAttributes<HTMLDivElement> {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (v: boolean) => void;
+}
+
+const SidebarProvider = React.forwardRef<HTMLDivElement, SidebarProviderProps>(
+  (
+    {
+      defaultOpen = true,
+      open: openProp,
+      onOpenChange,
+      className,
+      style,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [_open, _setOpen] = React.useState(defaultOpen);
+    const isControlled = openProp !== undefined;
+    const open = isControlled ? openProp : _open;
+    const setOpen = React.useCallback(
+      (v: boolean) => {
+        if (!isControlled) _setOpen(v);
+        onOpenChange?.(v);
+      },
+      [isControlled, onOpenChange]
+    );
+    const toggle = React.useCallback(() => setOpen(!open), [open, setOpen]);
+    const value = React.useMemo(
+      () => ({ open, setOpen, toggle }),
+      [open, setOpen, toggle]
+    );
+
+    return (
+      <SidebarContext.Provider value={value}>
+        <div
+          ref={ref}
+          data-state={open ? "expanded" : "collapsed"}
+          className={cn("flex min-h-svh w-full", className)}
+          style={
+            {
+              "--sidebar-width": "16rem",
+              "--sidebar-width-collapsed": "3.5rem",
+              ...style,
+            } as React.CSSProperties
+          }
+          {...props}
+        >
+          {children}
+        </div>
+      </SidebarContext.Provider>
+    );
+  }
+);
+SidebarProvider.displayName = "SidebarProvider";
+
+const Sidebar = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(({ className, children, ...props }, ref) => {
+  const { open } = useSidebar();
+  return (
+    <aside
+      ref={ref}
+      data-state={open ? "expanded" : "collapsed"}
+      className={cn(
+        "flex flex-col bg-sidebar text-sidebar-foreground border-r transition-[width] duration-200 ease-linear",
+        "w-[--sidebar-width] data-[state=collapsed]:w-[--sidebar-width-collapsed]",
+        "overflow-hidden",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </aside>
+  );
+});
+Sidebar.displayName = "Sidebar";
+
+const SidebarTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, onClick, ...props }, ref) => {
+  const { toggle } = useSidebar();
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      className={cn("h-7 w-7", className)}
+      onClick={(e) => {
+        onClick?.(e);
+        toggle();
+      }}
+      {...props}
+    >
+      <PanelLeft className="h-4 w-4" />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+});
+SidebarTrigger.displayName = "SidebarTrigger";
+
+const SidebarInset = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(({ className, ...props }, ref) => (
+  <main
+    ref={ref}
+    className={cn("relative flex min-h-svh flex-1 flex-col bg-background", className)}
+    {...props}
+  />
+));
+SidebarInset.displayName = "SidebarInset";
+
+const SidebarHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col gap-2 p-2", className)}
+    {...props}
+  />
+));
+SidebarHeader.displayName = "SidebarHeader";
+
+const SidebarFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col gap-2 p-2 mt-auto", className)}
+    {...props}
+  />
+));
+SidebarFooter.displayName = "SidebarFooter";
+
+const SidebarContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex min-h-0 flex-1 flex-col gap-2 overflow-auto p-2", className)}
+    {...props}
+  />
+));
+SidebarContent.displayName = "SidebarContent";
+
+const SidebarGroup = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+    {...props}
+  />
+));
+SidebarGroup.displayName = "SidebarGroup";
+
+const SidebarGroupLabel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none transition-opacity",
+      "group-data-[state=collapsed]:opacity-0",
+      className
+    )}
+    {...props}
+  />
+));
+SidebarGroupLabel.displayName = "SidebarGroupLabel";
+
+const SidebarGroupContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("w-full text-sm", className)} {...props} />
+));
+SidebarGroupContent.displayName = "SidebarGroupContent";
+
+const SidebarMenu = React.forwardRef<
+  HTMLUListElement,
+  React.HTMLAttributes<HTMLUListElement>
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+    {...props}
+  />
+));
+SidebarMenu.displayName = "SidebarMenu";
+
+const SidebarMenuItem = React.forwardRef<
+  HTMLLIElement,
+  React.HTMLAttributes<HTMLLIElement>
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("group/menu-item relative", className)}
+    {...props}
+  />
+));
+SidebarMenuItem.displayName = "SidebarMenuItem";
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground",
+  {
+    variants: {
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+interface SidebarMenuButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof sidebarMenuButtonVariants> {
+  asChild?: boolean;
+  isActive?: boolean;
+}
+
+const SidebarMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  SidebarMenuButtonProps
+>(({ asChild = false, isActive = false, size, className, ...props }, ref) => {
+  const Comp: React.ElementType = asChild ? "span" : "button";
+  return (
+    <Comp
+      ref={ref}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+});
+SidebarMenuButton.displayName = "SidebarMenuButton";
+
+export {
+  Sidebar,
+  SidebarProvider,
+  SidebarTrigger,
+  SidebarInset,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  sidebarMenuButtonVariants,
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/globals.css
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/globals.css
@@ -41,6 +41,16 @@
     /* Layout */
     --page-max-width: 80rem;
     --sidebar-width: 12rem;
+
+    /* Sidebar */
+    --sidebar-background: 0 0% 98%;
+    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-primary: 240 5.9% 10%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-border: 220 13% 91%;
+    --sidebar-ring: 217.2 91.2% 59.8%;
   }
 
   .dark {
@@ -69,6 +79,16 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+
+    /* Sidebar — dark */
+    --sidebar-background: 240 5.9% 10%;
+    --sidebar-foreground: 240 4.8% 95.9%;
+    --sidebar-primary: 224.3 76.3% 48%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 240 3.7% 15.9%;
+    --sidebar-accent-foreground: 240 4.8% 95.9%;
+    --sidebar-border: 240 3.7% 15.9%;
+    --sidebar-ring: 217.2 91.2% 59.8%;
   }
 }
 

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/index.ts
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/index.ts
@@ -50,6 +50,49 @@ export {
   ChartLegend, ChartLegendContent, type ChartConfig,
 } from "./components/ui/chart";
 
+// Overlays & disclosures
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent } from "./components/ui/popover";
+export {
+  AlertDialog, AlertDialogPortal, AlertDialogOverlay, AlertDialogTrigger,
+  AlertDialogContent, AlertDialogHeader, AlertDialogFooter, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogAction, AlertDialogCancel,
+} from "./components/ui/alert-dialog";
+export { Collapsible, CollapsibleTrigger, CollapsibleContent } from "./components/ui/collapsible";
+export {
+  Accordion, AccordionItem, AccordionTrigger, AccordionContent,
+} from "./components/ui/accordion";
+
+// Data entry
+export { Calendar, type CalendarProps } from "./components/ui/calendar";
+export { DatePicker, type DatePickerProps } from "./components/ui/date-picker";
+export { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
+export { Combobox, type ComboboxProps, type ComboboxOption } from "./components/ui/combobox";
+export {
+  Form, FormField, FormItem, FormLabel, FormControl,
+  FormDescription, FormMessage, useFormField,
+} from "./components/ui/form";
+
+// Command palette
+export {
+  Command, CommandDialog, CommandInput, CommandList, CommandEmpty,
+  CommandGroup, CommandItem, CommandShortcut, CommandSeparator,
+} from "./components/ui/command";
+
+// Navigation
+export {
+  NavigationMenu, NavigationMenuList, NavigationMenuItem,
+  NavigationMenuContent, NavigationMenuTrigger, NavigationMenuLink,
+  NavigationMenuIndicator, NavigationMenuViewport,
+  navigationMenuTriggerStyle,
+} from "./components/ui/navigation-menu";
+export {
+  Sidebar, SidebarProvider, SidebarTrigger, SidebarInset,
+  SidebarHeader, SidebarFooter, SidebarContent,
+  SidebarGroup, SidebarGroupLabel, SidebarGroupContent,
+  SidebarMenu, SidebarMenuItem, SidebarMenuButton,
+  sidebarMenuButtonVariants, useSidebar,
+} from "./components/ui/sidebar";
+
 // Layout
 export { Page } from "./components/layout/Page";
 export { PageHeader } from "./components/layout/PageHeader";

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/tailwind-preset.ts
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/tailwind-preset.ts
@@ -45,11 +45,35 @@ const preset: Partial<Config> = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
       },
     },
   },

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Accordion.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Accordion.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Accordion, AccordionItem, AccordionTrigger, AccordionContent,
+} from "../src";
+
+const meta: Meta<typeof Accordion> = {
+  title: "Components/Accordion",
+  component: Accordion,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+export const Default: Story = {
+  render: () => (
+    <Accordion type="single" collapsible className="w-80">
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Is it accessible?</AccordionTrigger>
+        <AccordionContent>Yes. Built on Radix primitives, follows WAI-ARIA.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>Is it styled?</AccordionTrigger>
+        <AccordionContent>Yes. Tailwind + shadcn theme, ready to use.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger>Is it animated?</AccordionTrigger>
+        <AccordionContent>Yes. Uses CSS keyframes for open/close transitions.</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/AlertDialog.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/AlertDialog.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  AlertDialog, AlertDialogTrigger, AlertDialogContent,
+  AlertDialogHeader, AlertDialogFooter, AlertDialogTitle,
+  AlertDialogDescription, AlertDialogAction, AlertDialogCancel,
+  Button,
+} from "../src";
+
+const meta: Meta<typeof AlertDialog> = {
+  title: "Components/AlertDialog",
+  component: AlertDialog,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof AlertDialog>;
+
+export const Default: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete account</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. It will permanently delete your account.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Calendar.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Calendar.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Calendar } from "../src";
+
+const meta: Meta<typeof Calendar> = {
+  title: "Components/Calendar",
+  component: Calendar,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Calendar>;
+
+export const Default: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | undefined>(new Date());
+    return (
+      <Calendar
+        mode="single"
+        selected={date}
+        onSelect={setDate}
+        className="rounded-md border"
+      />
+    );
+  },
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Collapsible.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Collapsible.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ChevronsUpDown } from "lucide-react";
+import {
+  Collapsible, CollapsibleTrigger, CollapsibleContent, Button,
+} from "../src";
+
+const meta: Meta<typeof Collapsible> = {
+  title: "Components/Collapsible",
+  component: Collapsible,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Collapsible>;
+
+export const Default: Story = {
+  render: () => (
+    <Collapsible className="w-80 space-y-2">
+      <div className="flex items-center justify-between space-x-4 px-4">
+        <h4 className="text-sm font-semibold">@jane-doe starred 3 repositories</h4>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="icon" className="w-9 p-0">
+            <ChevronsUpDown className="h-4 w-4" />
+            <span className="sr-only">Toggle</span>
+          </Button>
+        </CollapsibleTrigger>
+      </div>
+      <div className="rounded-md border px-4 py-3 text-sm">@radix-ui/primitives</div>
+      <CollapsibleContent className="space-y-2">
+        <div className="rounded-md border px-4 py-3 text-sm">@radix-ui/colors</div>
+        <div className="rounded-md border px-4 py-3 text-sm">@stitches/react</div>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Combobox.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Combobox.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Combobox } from "../src";
+
+const meta: Meta<typeof Combobox> = {
+  title: "Components/Combobox",
+  component: Combobox,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Combobox>;
+
+const frameworks = [
+  { value: "next.js", label: "Next.js" },
+  { value: "sveltekit", label: "SvelteKit" },
+  { value: "nuxt.js", label: "Nuxt.js" },
+  { value: "remix", label: "Remix" },
+  { value: "astro", label: "Astro" },
+];
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>();
+    return (
+      <div className="w-72">
+        <Combobox
+          options={frameworks}
+          value={value}
+          onChange={setValue}
+          placeholder="Select framework..."
+          searchPlaceholder="Search framework..."
+          emptyText="No framework found."
+        />
+      </div>
+    );
+  },
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Command.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Command.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Command, CommandInput, CommandList, CommandEmpty,
+  CommandGroup, CommandItem, CommandSeparator, CommandShortcut,
+} from "../src";
+
+const meta: Meta<typeof Command> = {
+  title: "Components/Command",
+  component: Command,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Command>;
+
+export const Default: Story = {
+  render: () => (
+    <Command className="rounded-lg border shadow-md w-80">
+      <CommandInput placeholder="Type a command..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem>Calendar</CommandItem>
+          <CommandItem>Search Emoji</CommandItem>
+          <CommandItem>Calculator</CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Settings">
+          <CommandItem>
+            Profile
+            <CommandShortcut>⌘P</CommandShortcut>
+          </CommandItem>
+          <CommandItem>
+            Billing
+            <CommandShortcut>⌘B</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/DatePicker.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/DatePicker.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { DatePicker } from "../src";
+
+const meta: Meta<typeof DatePicker> = {
+  title: "Components/DatePicker",
+  component: DatePicker,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof DatePicker>;
+
+export const Default: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | undefined>();
+    return (
+      <div className="w-72">
+        <DatePicker value={date} onChange={setDate} />
+      </div>
+    );
+  },
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Form.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Form.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Form, FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage,
+  Input, Button,
+} from "../src";
+
+const meta: Meta = {
+  title: "Components/Form",
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj;
+
+const schema = z.object({
+  username: z.string().min(2, "Username must be at least 2 characters."),
+  email: z.string().email("Invalid email address."),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export const Default: Story = {
+  render: () => {
+    const form = useForm<FormValues>({
+      resolver: zodResolver(schema),
+      defaultValues: { username: "", email: "" },
+    });
+    return (
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit((v) => console.log(v))} className="w-80 space-y-6">
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Username</FormLabel>
+                <FormControl>
+                  <Input placeholder="jane-doe" {...field} />
+                </FormControl>
+                <FormDescription>Public display name.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input type="email" placeholder="jane@example.com" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit">Submit</Button>
+        </form>
+      </Form>
+    );
+  },
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/NavigationMenu.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/NavigationMenu.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  NavigationMenu, NavigationMenuList, NavigationMenuItem,
+  NavigationMenuTrigger, NavigationMenuContent, NavigationMenuLink,
+  navigationMenuTriggerStyle,
+} from "../src";
+import { cn } from "../src/lib/utils";
+
+const meta: Meta<typeof NavigationMenu> = {
+  title: "Components/NavigationMenu",
+  component: NavigationMenu,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof NavigationMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-[300px] gap-2 p-4">
+              <li><NavigationMenuLink className="block p-2 rounded hover:bg-accent">HRM</NavigationMenuLink></li>
+              <li><NavigationMenuLink className="block p-2 rounded hover:bg-accent">Recruitment</NavigationMenuLink></li>
+              <li><NavigationMenuLink className="block p-2 rounded hover:bg-accent">Finance</NavigationMenuLink></li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink className={cn(navigationMenuTriggerStyle())}>Docs</NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Popover.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Popover.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Popover, PopoverContent, PopoverTrigger, Button } from "../src";
+
+const meta: Meta<typeof Popover> = {
+  title: "Components/Popover",
+  component: Popover,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <p className="text-sm">Anchored popover content. Put any JSX in here.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/RadioGroup.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/RadioGroup.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { RadioGroup, RadioGroupItem, Label } from "../src";
+
+const meta: Meta<typeof RadioGroup> = {
+  title: "Components/RadioGroup",
+  component: RadioGroup,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
+
+export const Default: Story = {
+  render: () => (
+    <RadioGroup defaultValue="comfortable">
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="default" id="r1" />
+        <Label htmlFor="r1">Default</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="comfortable" id="r2" />
+        <Label htmlFor="r2">Comfortable</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <RadioGroupItem value="compact" id="r3" />
+        <Label htmlFor="r3">Compact</Label>
+      </div>
+    </RadioGroup>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Sidebar.stories.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/stories/Sidebar.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Home, Users, Settings } from "lucide-react";
+import {
+  Sidebar, SidebarProvider, SidebarTrigger, SidebarInset,
+  SidebarHeader, SidebarContent, SidebarGroup, SidebarGroupLabel,
+  SidebarGroupContent, SidebarMenu, SidebarMenuItem, SidebarMenuButton,
+} from "../src";
+
+const meta: Meta<typeof Sidebar> = {
+  title: "Components/Sidebar",
+  component: Sidebar,
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj<typeof Sidebar>;
+
+export const Default: Story = {
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader>
+          <span className="font-semibold px-2">Acme HR</span>
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Main</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton isActive>
+                    <Home className="h-4 w-4" />
+                    <span>Dashboard</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>
+                    <Users className="h-4 w-4" />
+                    <span>Employees</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>
+                    <Settings className="h-4 w-4" />
+                    <span>Settings</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+      </Sidebar>
+      <SidebarInset>
+        <header className="flex h-12 items-center gap-2 border-b px-4">
+          <SidebarTrigger />
+          <span className="text-sm font-medium">Content area</span>
+        </header>
+        <main className="p-4">
+          <p className="text-sm text-muted-foreground">
+            Click the toggle to collapse the sidebar.
+          </p>
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
+  ),
+};

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/tailwind.config.ts
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/tailwind.config.ts
@@ -43,11 +43,35 @@ const config: Config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
       },
     },
   },

--- a/tests/test_ui_kit.py
+++ b/tests/test_ui_kit.py
@@ -179,6 +179,30 @@ def test_tailwind_preset_exposes_sidebar_colors(uikit_src: Path) -> None:
 # ── Stories ────────────────────────────────────────────────────────────────
 
 
+def test_generated_output_has_no_jinja_residue(uikit_src: Path) -> None:
+    """Nothing in the generated project should still contain Jinja markers.
+
+    We burned on this once — a ``{% raw %}`` block that was never processed
+    leaked into emitted .tsx/.json/.ts files, breaking them at parse time.
+    Scan every generated source file for tell-tale Jinja syntax.
+    """
+    bad_patterns = ["{% raw %}", "{% endraw %}"]
+    project_root = uikit_src.parent
+    scan_extensions = {".ts", ".tsx", ".js", ".jsx", ".json", ".css", ".md"}
+    offenders: list[tuple[str, str]] = []
+    for path in project_root.rglob("*"):
+        if not path.is_file() or path.suffix not in scan_extensions:
+            continue
+        # Skip node_modules / dist / .git if a previous run populated them
+        if any(part in {"node_modules", "dist", ".git"} for part in path.parts):
+            continue
+        content = path.read_text(errors="ignore")
+        for pat in bad_patterns:
+            if pat in content:
+                offenders.append((str(path.relative_to(project_root)), pat))
+    assert not offenders, f"Jinja residue in generated output: {offenders}"
+
+
 def test_phase_0_stories_exist(uikit_src: Path) -> None:
     stories_dir = uikit_src.parent / "stories"
     expected_stories = [

--- a/tests/test_ui_kit.py
+++ b/tests/test_ui_kit.py
@@ -1,0 +1,199 @@
+"""Tests for the ui-kit template — component presence, barrel exports, deps."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from apps_generator.core.generator import generate
+from apps_generator.templates.registry import resolve_template
+
+
+# ── Fixture: one generated ui-kit per test module ──────────────────────────
+
+
+@pytest.fixture(scope="module")
+def uikit_src(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Generate a ui-kit project once and return its ``src/`` directory."""
+    # mktemp() creates a dir; generate() refuses an existing output dir, so nest a
+    # fresh subpath that generate() will create itself.
+    parent = tmp_path_factory.mktemp("ui-kit-parent")
+    template = resolve_template("ui-kit")
+    result = generate(
+        template_dir=template.path,
+        output_dir=parent / "out",
+        cli_values={"projectName": "test-ui"},
+        interactive=False,
+    )
+    return result / "test-ui" / "src"
+
+
+# ── Core inventory ─────────────────────────────────────────────────────────
+
+# Every component file we expect under src/components/ui/. Keep this in sync
+# with the full shadcn catalog we ship.
+EXPECTED_COMPONENTS = [
+    # Pre-existing (26)
+    "alert",
+    "avatar",
+    "badge",
+    "breadcrumb",
+    "button",
+    "card",
+    "chart",
+    "checkbox",
+    "dialog",
+    "dropdown-menu",
+    "input",
+    "label",
+    "pagination",
+    "progress",
+    "scroll-area",
+    "select",
+    "separator",
+    "sheet",
+    "skeleton",
+    "switch",
+    "table",
+    "tabs",
+    "textarea",
+    "toast",
+    "toaster",
+    "tooltip",
+    # Phase 0 additions (12)
+    "accordion",
+    "alert-dialog",
+    "calendar",
+    "collapsible",
+    "combobox",
+    "command",
+    "date-picker",
+    "form",
+    "navigation-menu",
+    "popover",
+    "radio-group",
+    "sidebar",
+]
+
+
+def test_all_expected_component_files_exist(uikit_src: Path) -> None:
+    ui_dir = uikit_src / "components" / "ui"
+    missing = [name for name in EXPECTED_COMPONENTS if not (ui_dir / f"{name}.tsx").exists()]
+    assert not missing, f"Missing component files: {missing}"
+
+
+@pytest.mark.parametrize(
+    "component,expected_exports",
+    [
+        ("popover", ["Popover", "PopoverTrigger", "PopoverContent"]),
+        ("calendar", ["Calendar"]),
+        ("date-picker", ["DatePicker"]),
+        ("form", ["Form", "FormField", "FormItem", "FormLabel", "FormControl", "FormMessage"]),
+        ("radio-group", ["RadioGroup", "RadioGroupItem"]),
+        ("command", ["Command", "CommandInput", "CommandList", "CommandItem"]),
+        ("combobox", ["Combobox"]),
+        ("alert-dialog", ["AlertDialog", "AlertDialogAction", "AlertDialogCancel"]),
+        ("collapsible", ["Collapsible", "CollapsibleTrigger", "CollapsibleContent"]),
+        ("accordion", ["Accordion", "AccordionItem", "AccordionTrigger", "AccordionContent"]),
+        ("sidebar", ["Sidebar", "SidebarProvider", "SidebarMenu", "SidebarMenuButton"]),
+        ("navigation-menu", ["NavigationMenu", "NavigationMenuList", "NavigationMenuTrigger"]),
+    ],
+)
+def test_component_exports_expected_symbols(
+    uikit_src: Path, component: str, expected_exports: list[str]
+) -> None:
+    content = (uikit_src / "components" / "ui" / f"{component}.tsx").read_text()
+    for sym in expected_exports:
+        assert f"{sym}" in content, f"{component}.tsx missing symbol {sym!r}"
+
+
+# ── Barrel (index.ts) ──────────────────────────────────────────────────────
+
+
+def test_index_ts_reexports_phase_0_components(uikit_src: Path) -> None:
+    index = (uikit_src / "index.ts").read_text()
+    phase_0_symbols = [
+        "Popover",
+        "Calendar",
+        "DatePicker",
+        "Form",
+        "FormField",
+        "RadioGroup",
+        "Combobox",
+        "Command",
+        "AlertDialog",
+        "Collapsible",
+        "Accordion",
+        "Sidebar",
+        "SidebarProvider",
+        "NavigationMenu",
+    ]
+    missing = [s for s in phase_0_symbols if s not in index]
+    assert not missing, f"index.ts missing re-exports: {missing}"
+
+
+# ── Dependencies ───────────────────────────────────────────────────────────
+
+
+def test_phase_0_dependencies_declared(uikit_src: Path) -> None:
+    pkg_json = json.loads((uikit_src.parent / "package.json").read_text())
+    deps = pkg_json["dependencies"]
+    required = [
+        "@hookform/resolvers",
+        "@radix-ui/react-accordion",
+        "@radix-ui/react-alert-dialog",
+        "@radix-ui/react-collapsible",
+        "@radix-ui/react-navigation-menu",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-radio-group",
+        "cmdk",
+        "date-fns",
+        "react-day-picker",
+        "react-hook-form",
+        "zod",
+    ]
+    missing = [d for d in required if d not in deps]
+    assert not missing, f"Missing phase-0 dependencies: {missing}"
+
+
+# ── Sidebar theme tokens ───────────────────────────────────────────────────
+
+
+def test_globals_css_has_sidebar_theme_vars(uikit_src: Path) -> None:
+    css = (uikit_src / "globals.css").read_text()
+    # light + dark both define sidebar vars
+    assert css.count("--sidebar-background:") >= 2
+    assert "--sidebar-foreground:" in css
+    assert "--sidebar-accent:" in css
+
+
+def test_tailwind_preset_exposes_sidebar_colors(uikit_src: Path) -> None:
+    preset = (uikit_src / "tailwind-preset.ts").read_text()
+    assert "sidebar:" in preset
+    assert "hsl(var(--sidebar-background))" in preset
+    assert "accordion-down" in preset
+
+
+# ── Stories ────────────────────────────────────────────────────────────────
+
+
+def test_phase_0_stories_exist(uikit_src: Path) -> None:
+    stories_dir = uikit_src.parent / "stories"
+    expected_stories = [
+        "Popover",
+        "Calendar",
+        "DatePicker",
+        "Form",
+        "RadioGroup",
+        "Command",
+        "Combobox",
+        "AlertDialog",
+        "Collapsible",
+        "Accordion",
+        "Sidebar",
+        "NavigationMenu",
+    ]
+    missing = [s for s in expected_stories if not (stories_dir / f"{s}.stories.tsx").exists()]
+    assert not missing, f"Missing story files: {missing}"

--- a/tests/test_ui_kit.py
+++ b/tests/test_ui_kit.py
@@ -101,9 +101,7 @@ def test_all_expected_component_files_exist(uikit_src: Path) -> None:
         ("navigation-menu", ["NavigationMenu", "NavigationMenuList", "NavigationMenuTrigger"]),
     ],
 )
-def test_component_exports_expected_symbols(
-    uikit_src: Path, component: str, expected_exports: list[str]
-) -> None:
+def test_component_exports_expected_symbols(uikit_src: Path, component: str, expected_exports: list[str]) -> None:
     content = (uikit_src / "components" / "ui" / f"{component}.tsx").read_text()
     for sym in expected_exports:
         assert f"{sym}" in content, f"{component}.tsx missing symbol {sym!r}"


### PR DESCRIPTION
## Summary

Phase 0 of the page-type catalog refactor — expands `ui-kit` with the 12 shadcn components that unblock every remaining page type (`detail`, `edit`, `grid`, `kanban`, `calendar`, `tree`, `settings`). Without this, new page emitters have no primitives to compose against.

| Family | Components |
|---|---|
| Overlays/disclosures | Popover, AlertDialog, Collapsible, Accordion |
| Data entry | Calendar, DatePicker, RadioGroup, Combobox, Form |
| Command palette | Command (cmdk) |
| Navigation | Sidebar, NavigationMenu |

Each component follows the existing shadcn + `cva` + `forwardRef` + `displayName` conventions, is re-exported from the barrel, and gets a CSF3 Storybook entry with a working `Default` story.

## Plumbing changes

- **`package.json`** — adds `@radix-ui/*` (popover, radio-group, alert-dialog, collapsible, accordion, navigation-menu), `react-day-picker` + `date-fns`, `react-hook-form` + `@hookform/resolvers` + `zod`, `cmdk`
- **`globals.css`** — sidebar CSS variables for light + dark
- **`tailwind-preset.ts` + `tailwind.config.ts`** — `sidebar.*` color tokens and accordion-up/down keyframes
- **`linking.py`** — emits the same tokens + accordion animation into consumer tailwind configs, plus safelist entries for the new component classes (so Module Federation consumers get the classes)

## Test plan

- [x] 18 new tests in `tests/test_ui_kit.py` covering:
  - Every expected component file exists under `src/components/ui/`
  - Each component exports its expected symbols (Popover, Calendar, Form, Combobox, Sidebar, …)
  - `index.ts` re-exports every Phase 0 symbol
  - `package.json` declares each new dependency
  - `globals.css` has sidebar theme vars (light + dark)
  - `tailwind-preset.ts` exposes sidebar color tokens + accordion keyframes
  - All 12 Storybook entries exist
- [x] **Full suite: 117/117 passing** (18 new + 99 pre-existing)
- [x] **Verified end-to-end** by generating the fixture, `npm install`, and launching Storybook on port 6006 — every new component renders, `DatePicker` popover opens, `Sidebar` collapses, `Form` Zod validation fires, `Combobox` filters.

## Gotcha worth noting

`form.tsx` and `calendar.tsx` are wrapped in `{% raw %}` / `{% endraw %}` because they use JSX double-brace patterns like `value={{ name: props.name }}` that collide with Jinja. Matches the existing convention used by `tooltip.tsx`, `dropdown-menu.tsx`, etc.
