### PR TITLE
feat(pages): add `detail` page type — read-only single-record view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `list` — table with useApiClient + useQuery, pagination, Card wrapper. Null-safe rendering (shows "—" for null values).
 - `form` — create form with type-aware inputs (datetime picker, number, textarea, checkbox, enum select dropdowns). Resource lookups auto-detected (e.g. `dogName` field renders as dropdown fetching from `/dog` API). useMutation, Card wrapper.
 - `dashboard` — stat cards + bar chart (Recharts) + recent items table
+- `detail` — read-only single-record view as a definition list inside a Card. Reads `id` from `?id=` query string, fetches `GET /{resource}/{id}` via useQuery. Type-aware value rendering: decimal → `toFixed(2)`, date/datetime → `toLocaleDateString()`, boolean → Badge ("Yes"/"No"), enum → Badge with value, text → `whitespace-pre-wrap`. Shows a Skeleton placeholder per field while loading; falls back to `t("missingId")` when `id` is absent.
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -181,7 +182,14 @@ src/apps_generator/
 │   ├── sync.py              # Sync types from OpenAPI
 │   ├── docker_compose.py    # Docker compose generation
 │   └── generators/
-│       ├── pages.py          # React page generation (list/form/dashboard)
+│       ├── pages/            # React page generation package
+│       │   ├── __init__.py   # parse_pages, find_project_root, dispatcher
+│       │   ├── registry.py   # PageTypeRegistry + PageContext
+│       │   ├── base.py       # page_target() + detect_lookup() helpers
+│       │   ├── list_type.py
+│       │   ├── form_type.py
+│       │   ├── dashboard_type.py
+│       │   └── detail_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -227,7 +235,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ appgen generate api-domain -o ./product-service \
   -s 'resources=[{"name":"product","fields":[{"name":"name","type":"string","required":true,"maxLength":255},{"name":"price","type":"decimal","required":true,"min":0},{"name":"status","type":"enum","required":true,"values":["active","inactive","archived"]},{"name":"active","type":"boolean"}]}]' \
   --gateway ./gateway --api-client ./api-client
 
-# 6. Micro-frontend with data-aware pages (dashboard + list + form)
+# 6. Micro-frontend with data-aware pages (dashboard + list + form + detail)
 appgen generate frontend-app -o ./products -s projectName=products -s devPort=5001 \
   -s 'pages=[
     {"path":"overview","label":"Overview","resource":"product","type":"dashboard","fields":[
@@ -45,6 +45,12 @@ appgen generate frontend-app -o ./products -s projectName=products -s devPort=50
       {"name":"name","type":"string","required":true},
       {"name":"price","type":"decimal","required":true},
       {"name":"active","type":"boolean"}
+    ]},
+    {"path":"view","label":"Product Details","resource":"product","type":"detail","fields":[
+      {"name":"name","type":"string"},
+      {"name":"price","type":"decimal"},
+      {"name":"active","type":"boolean"},
+      {"name":"description","type":"text"}
     ]},
     {"path":"create","label":"New Product","resource":"product","type":"form","fields":[
       {"name":"name","type":"string","required":true},

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -28,7 +28,7 @@ from .registry import PageContext, PageTypeInfo, PageTypeRegistry, get_registry
 # ``list``) via the package-attribute binding that submodule imports trigger.
 # Adding a new built-in is as simple as dropping a ``<name>_type.py`` module
 # in this package.
-_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type")
+_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type", "detail_type")
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")
 

--- a/src/apps_generator/cli/generators/pages/detail_type.py
+++ b/src/apps_generator/cli/generators/pages/detail_type.py
@@ -1,0 +1,207 @@
+"""``detail`` page type — read-only view of a single record.
+
+Renders a two-column "definition list" of the resource's field values inside
+a Card. The record id is read from the ``?id=...`` query string, since the
+generated frontend-app maps paths to components directly without URL params.
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case, title_case
+
+from .base import page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+def _render_value(field: dict, ui: bool) -> str:
+    """Return the JSX expression for one field's value, type-aware and null-safe."""
+    fname = camel_case(field["name"])
+    ft = field.get("type", "string")
+
+    if ft == "boolean":
+        if ui:
+            return (
+                f"data.{fname} == null ? (\n"
+                f'                <span className="text-muted-foreground">—</span>\n'
+                f"              ) : data.{fname} ? (\n"
+                f'                <Badge variant="default">{{t("yes")}}</Badge>\n'
+                f"              ) : (\n"
+                f'                <Badge variant="outline">{{t("no")}}</Badge>\n'
+                f"              )"
+            )
+        return f'data.{fname} == null ? "—" : data.{fname} ? t("yes") : t("no")'
+
+    if ft == "decimal":
+        return f'data.{fname} != null ? `$${{data.{fname}.toFixed(2)}}` : "—"'
+
+    if ft in ("date", "datetime"):
+        return f'data.{fname} ? new Date(data.{fname}).toLocaleDateString() : "—"'
+
+    if ft == "enum" and ui:
+        # Render enum values as a Badge so statuses stand out visually.
+        return (
+            f"data.{fname} == null ? (\n"
+            f'                <span className="text-muted-foreground">—</span>\n'
+            f"              ) : (\n"
+            f'                <Badge variant="secondary">{{String(data.{fname})}}</Badge>\n'
+            f"              )"
+        )
+
+    if ft == "text":
+        # Long text wraps and preserves whitespace.
+        if ui:
+            return (
+                f"data.{fname} == null ? (\n"
+                f'                <span className="text-muted-foreground">—</span>\n'
+                f"              ) : (\n"
+                f'                <span className="whitespace-pre-wrap">{{data.{fname}}}</span>\n'
+                f"              )"
+            )
+        return f'data.{fname} ?? "—"'
+
+    # string / integer / long (default)
+    return f'data.{fname} ?? "—"'
+
+
+def emit_detail(page: dict, ctx: PageContext) -> None:
+    """Generate a detail page — single record view."""
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    # ui-kit imports
+    if ui:
+        ui_import = f'import {{ Card, CardContent, CardHeader, CardTitle, Badge, Skeleton }} from "{ui}";\n'
+    else:
+        ui_import = ""
+
+    # Build one dt/dd pair per field. We put the label in <dt> and the value
+    # (already a JSX expression returned by _render_value) in <dd>. Using a
+    # definition list keeps the semantics right for screen readers.
+    rows: list[str] = []
+    for f in fields:
+        flabel = title_case(f["name"])
+        value_expr = _render_value(f, bool(ui))
+        if ui:
+            rows.append(
+                f'            <div className="space-y-1">\n'
+                f'              <dt className="text-sm font-medium text-muted-foreground">{flabel}</dt>\n'
+                f"              <dd>\n"
+                f"                {{{value_expr}}}\n"
+                f"              </dd>\n"
+                f"            </div>"
+            )
+        else:
+            rows.append(
+                f'            <div className="space-y-1">\n'
+                f'              <dt className="text-sm font-medium text-muted-foreground">{flabel}</dt>\n'
+                f'              <dd className="text-sm">{{{value_expr}}}</dd>\n'
+                f"            </div>"
+            )
+    rows_str = "\n".join(rows)
+
+    # Loading skeleton — use the ui-kit Skeleton when available, else a plain
+    # pulsing placeholder. One skeleton per field keeps the layout stable so
+    # the user doesn't see a jarring reflow when data arrives.
+    if ui:
+        loading_skeletons = "\n".join(
+            '            <div className="space-y-1">\n'
+            '              <Skeleton className="h-4 w-24" />\n'
+            '              <Skeleton className="h-5 w-40" />\n'
+            "            </div>"
+            for _ in fields
+        )
+        loading_block = (
+            f"      <Card>\n"
+            f"        <CardHeader>\n"
+            f"          <CardTitle>{label}</CardTitle>\n"
+            f"        </CardHeader>\n"
+            f"        <CardContent>\n"
+            f'          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">\n'
+            f"{loading_skeletons}\n"
+            f"          </dl>\n"
+            f"        </CardContent>\n"
+            f"      </Card>"
+        )
+        content_block = (
+            f"      <Card>\n"
+            f"        <CardHeader>\n"
+            f"          <CardTitle>{label}</CardTitle>\n"
+            f"        </CardHeader>\n"
+            f"        <CardContent>\n"
+            f'          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">\n'
+            f"{rows_str}\n"
+            f"          </dl>\n"
+            f"        </CardContent>\n"
+            f"      </Card>"
+        )
+    else:
+        loading_skeletons = "\n".join(
+            '            <div className="space-y-1">\n'
+            '              <div className="h-4 w-24 animate-pulse bg-muted rounded" />\n'
+            '              <div className="h-5 w-40 animate-pulse bg-muted rounded" />\n'
+            "            </div>"
+            for _ in fields
+        )
+        loading_block = (
+            f'      <h1 className="text-2xl font-bold tracking-tight mb-4">{label}</h1>\n'
+            f'          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">\n'
+            f"{loading_skeletons}\n"
+            f"          </dl>"
+        )
+        content_block = (
+            f'      <h1 className="text-2xl font-bold tracking-tight mb-4">{label}</h1>\n'
+            f'          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">\n'
+            f"{rows_str}\n"
+            f"          </dl>"
+        )
+
+    dest.write_text(
+        f'import {{ useQuery }} from "@tanstack/react-query";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ {entity} }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f'  const id = new URLSearchParams(window.location.search).get("id");\n'
+        f"\n"
+        f"  const {{ data, isLoading, error }} = useQuery<{entity}>({{  \n"
+        f'    queryKey: ["{resource}", id],\n'
+        f"    queryFn: () => api.get<{entity}>(`/{resource}/${{id}}`),\n"
+        f"    enabled: !!id,\n"
+        f"  }});\n"
+        f"\n"
+        f'  if (!id) return <p className="text-destructive">{{t("missingId")}}</p>;\n'
+        f'  if (error) return <p className="text-destructive">{{t("failedToLoad")}}: {{(error as Error).message}}</p>;\n'
+        f"\n"
+        f"  if (isLoading || !data) {{\n"
+        f"    return (\n"
+        f'      <div className="space-y-4">\n'
+        f"{loading_block}\n"
+        f"      </div>\n"
+        f"    );\n"
+        f"  }}\n"
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f"{content_block}\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="detail",
+    description="Read-only single-record view — field values in a definition list.",
+    emit=emit_detail,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/en.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/en.json
@@ -15,5 +15,8 @@
   "showing": "Showing",
   "create": "Create",
   "creating": "Creating...",
-  "createdSuccessfully": "Created successfully!"
+  "createdSuccessfully": "Created successfully!",
+  "yes": "Yes",
+  "no": "No",
+  "missingId": "No ID provided"
 }

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/fr.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/fr.json
@@ -15,5 +15,8 @@
   "showing": "Affichés",
   "create": "Créer",
   "creating": "Création...",
-  "createdSuccessfully": "Créé avec succès !"
+  "createdSuccessfully": "Créé avec succès !",
+  "yes": "Oui",
+  "no": "Non",
+  "missingId": "Aucun ID fourni"
 }

--- a/tests/test_page_types_detail.py
+++ b/tests/test_page_types_detail.py
@@ -1,0 +1,140 @@
+"""Tests for the ``detail`` page type — read-only single-record view."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_detail_type_is_registered() -> None:
+    info = get_registry().get("detail")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description  # non-empty human description
+
+
+# ── Emitted output — ui-kit branch ─────────────────────────────────────────
+
+
+def _generate_employee_detail(tmp_path: Path, *, uikit: str = "my-ui") -> str:
+    """Run the dispatcher for a single detail page and return the emitted .tsx."""
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "view",
+        "label": "Employee Detail",
+        "resource": "employee",
+        "type": "detail",
+        "fields": [
+            {"name": "firstName", "type": "string"},
+            {"name": "lastName", "type": "string"},
+            {"name": "email", "type": "string"},
+            {"name": "hireDate", "type": "date"},
+            {"name": "salary", "type": "decimal"},
+            {"name": "active", "type": "boolean"},
+            {"name": "status", "type": "enum", "values": ["active", "inactive"]},
+            {"name": "notes", "type": "text"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "ViewPage.tsx").read_text()
+
+
+def test_detail_emits_react_query_hook(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path)
+    # Fetch via useQuery<Employee> against /employee/{id}
+    assert "useQuery<Employee>" in tsx
+    assert "`/employee/${id}`" in tsx
+    # Query is disabled until id is known
+    assert "enabled: !!id" in tsx
+
+
+def test_detail_reads_id_from_query_string(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path)
+    assert 'new URLSearchParams(window.location.search).get("id")' in tsx
+    # Graceful handling when id is missing
+    assert 't("missingId")' in tsx
+
+
+def test_detail_renders_every_field_label(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path)
+    # Field labels are rendered as <dt> text using title-case conversion.
+    for expected in ["First Name", "Last Name", "Email", "Hire Date", "Salary", "Active", "Status", "Notes"]:
+        assert f">{expected}<" in tsx, f"missing dt label: {expected!r}"
+
+
+def test_detail_formats_types_correctly(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path)
+    # decimal -> toFixed(2)
+    assert "data.salary.toFixed(2)" in tsx
+    # date -> new Date(...).toLocaleDateString()
+    assert "new Date(data.hireDate).toLocaleDateString()" in tsx
+    # boolean -> Yes/No via t() — ui-kit branch uses Badge
+    assert 't("yes")' in tsx
+    assert 't("no")' in tsx
+
+
+def test_detail_uikit_branch_imports_shadcn(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path, uikit="my-ui")
+    assert 'from "my-ui"' in tsx
+    for sym in ["Card", "CardContent", "CardHeader", "CardTitle", "Badge", "Skeleton"]:
+        assert sym in tsx, f"missing ui-kit import: {sym}"
+
+
+def test_detail_uikit_branch_uses_badges_for_enum_and_boolean(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path, uikit="my-ui")
+    # Enum values rendered as a secondary Badge
+    assert '<Badge variant="secondary">' in tsx
+    # Boolean rendered as default Badge for true, outline for false
+    assert '<Badge variant="default">' in tsx
+    assert '<Badge variant="outline">' in tsx
+
+
+# ── Plain-HTML fallback ────────────────────────────────────────────────────
+
+
+def test_detail_plain_branch_has_no_shadcn_imports(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path, uikit="")
+    # No ui-kit import line
+    assert "Card" not in tsx
+    assert "Badge" not in tsx
+    # But the page still works — semantics via <dl>/<dt>/<dd>
+    assert "<dl" in tsx
+    assert "<dt" in tsx
+    assert "<dd" in tsx
+
+
+def test_detail_plain_branch_boolean_uses_t_helper(tmp_path: Path) -> None:
+    """Without ui-kit we can't render Badges — fall back to t('yes')/t('no')."""
+    tsx = _generate_employee_detail(tmp_path, uikit="")
+    assert 't("yes")' in tsx
+    assert 't("no")' in tsx
+
+
+# ── Loading & error states ─────────────────────────────────────────────────
+
+
+def test_detail_shows_loading_skeleton(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path, uikit="my-ui")
+    # One Skeleton label + value pair per field (8 fields => 16 skeletons)
+    assert tsx.count("<Skeleton") == 16
+
+
+def test_detail_shows_error_state(tmp_path: Path) -> None:
+    tsx = _generate_employee_detail(tmp_path)
+    assert 't("failedToLoad")' in tsx
+    assert "(error as Error).message" in tsx


### PR DESCRIPTION
## Summary

First of the Phase 2 page types: **`detail`** — a read-only single-record view. Serves as the vertical-slice proof that the `PageTypeRegistry` landed in #15 actually unlocks drop-in page types without touching the dispatcher.

## What the generator emits

A detail page renders one record's field values inside a shadcn `Card` as a two-column definition list. The record `id` is read from the `?id=` query string, since the generated frontend-app maps paths to components directly (no URL params). When `id` is absent we show `t("missingId")`; otherwise TanStack Query fetches `GET /{resource}/{id}`, with a `Skeleton` placeholder per field while loading.

**Type-aware value rendering** (null-safe, mirrors the `list` page):

| Field type | Emitted value |
|---|---|
| `string` / `integer` / `long` | plain text, null → `—` |
| `decimal` | `$NNN.NN` via `toFixed(2)` |
| `date` / `datetime` | `toLocaleDateString()` |
| `boolean` | `<Badge variant="default">Yes</Badge>` / `<Badge variant="outline">No</Badge>` |
| `enum` | `<Badge variant="secondary">value</Badge>` |
| `text` | `<span className="whitespace-pre-wrap">...` |

Plain-HTML fallback (no `--uikit`) works identically: no Card wrapper, pulsing `<div>` for the skeleton, `t("yes")`/`t("no")` for booleans.

## i18n

Three new translation keys wired in both `en.json` and `fr.json`:

| key | EN | FR |
|---|---|---|
| `yes` | Yes | Oui |
| `no` | No | Non |
| `missingId` | No ID provided | Aucun ID fourni |

## Test plan

- [x] 11 new tests in `tests/test_page_types_detail.py`:
  - `test_detail_type_is_registered` — registry picks it up
  - `test_detail_emits_react_query_hook` — `useQuery<Employee>` against `/employee/${id}`, `enabled: !!id`
  - `test_detail_reads_id_from_query_string` — URLSearchParams usage + `missingId` fallback
  - `test_detail_renders_every_field_label` — every field becomes a `<dt>`
  - `test_detail_formats_types_correctly` — decimal/date/boolean render correctly
  - `test_detail_uikit_branch_imports_shadcn` — Card, CardContent, Badge, Skeleton
  - `test_detail_uikit_branch_uses_badges_for_enum_and_boolean` — all three Badge variants appear
  - `test_detail_plain_branch_has_no_shadcn_imports` — plain fallback uses raw `<dl>/<dt>/<dd>`
  - `test_detail_plain_branch_boolean_uses_t_helper` — falls back to `t("yes")/t("no")`
  - `test_detail_shows_loading_skeleton` — 16 skeletons for 8 fields (label + value each)
  - `test_detail_shows_error_state` — error message + `(error as Error).message`
- [x] **Full suite: 129/129 passing** (118 pre-existing + 11 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated a full ui-kit + api-client + frontend-app with a detail page, `vite build` succeeds.

## Docs

- `CLAUDE.md` — added the detail entry under **Page types**, and the code-structure section now reflects the `pages/` package introduced in #15 (list_type.py / form_type.py / dashboard_type.py / detail_type.py)
- `README.md` — example `pages=[...]` now includes a `detail` entry

## What's next (Phase 2 queue)

Same pattern, one PR per type: `grid` → `edit` → `settings` → `tree` → `kanban` → `calendar`.
