### PR TITLE
feat(pages): add `grid` page type — responsive card-grid view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `form` — create form with type-aware inputs (datetime picker, number, textarea, checkbox, enum select dropdowns). Resource lookups auto-detected (e.g. `dogName` field renders as dropdown fetching from `/dog` API). useMutation, Card wrapper.
 - `dashboard` — stat cards + bar chart (Recharts) + recent items table
 - `detail` — read-only single-record view as a definition list inside a Card. Reads `id` from `?id=` query string, fetches `GET /{resource}/{id}` via useQuery. Type-aware value rendering: decimal → `toFixed(2)`, date/datetime → `toLocaleDateString()`, boolean → Badge ("Yes"/"No"), enum → Badge with value, text → `whitespace-pre-wrap`. Shows a Skeleton placeholder per field while loading; falls back to `t("missingId")` when `id` is absent.
+- `grid` — responsive card-grid (1 col mobile / 2 md / 3 lg) for a resource collection. Same paginated query as `list`. First string field becomes the CardTitle, second becomes CardDescription; remaining fields drop into the card body as label/value pairs. Enum and boolean values render as Badges for fast visual scanning. Null-safe, shows empty state spanning all grid columns.
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -189,7 +190,8 @@ src/apps_generator/
 │       │   ├── list_type.py
 │       │   ├── form_type.py
 │       │   ├── dashboard_type.py
-│       │   └── detail_type.py
+│       │   ├── detail_type.py
+│       │   └── grid_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -235,7 +237,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard/detail) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail/grid) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ appgen generate api-domain -o ./product-service \
   -s 'resources=[{"name":"product","fields":[{"name":"name","type":"string","required":true,"maxLength":255},{"name":"price","type":"decimal","required":true,"min":0},{"name":"status","type":"enum","required":true,"values":["active","inactive","archived"]},{"name":"active","type":"boolean"}]}]' \
   --gateway ./gateway --api-client ./api-client
 
-# 6. Micro-frontend with data-aware pages (dashboard + list + form + detail)
+# 6. Micro-frontend with data-aware pages (dashboard + list + grid + form + detail)
 appgen generate frontend-app -o ./products -s projectName=products -s devPort=5001 \
   -s 'pages=[
     {"path":"overview","label":"Overview","resource":"product","type":"dashboard","fields":[
@@ -44,6 +44,12 @@ appgen generate frontend-app -o ./products -s projectName=products -s devPort=50
     {"path":"list","label":"Products","resource":"product","type":"list","fields":[
       {"name":"name","type":"string","required":true},
       {"name":"price","type":"decimal","required":true},
+      {"name":"active","type":"boolean"}
+    ]},
+    {"path":"catalog","label":"Catalog","resource":"product","type":"grid","fields":[
+      {"name":"name","type":"string"},
+      {"name":"description","type":"string"},
+      {"name":"price","type":"decimal"},
       {"name":"active","type":"boolean"}
     ]},
     {"path":"view","label":"Product Details","resource":"product","type":"detail","fields":[

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -28,7 +28,7 @@ from .registry import PageContext, PageTypeInfo, PageTypeRegistry, get_registry
 # ``list``) via the package-attribute binding that submodule imports trigger.
 # Adding a new built-in is as simple as dropping a ``<name>_type.py`` module
 # in this package.
-_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type", "detail_type")
+_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type", "detail_type", "grid_type")
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")
 

--- a/src/apps_generator/cli/generators/pages/grid_type.py
+++ b/src/apps_generator/cli/generators/pages/grid_type.py
@@ -1,0 +1,234 @@
+"""``grid`` page type — card-grid view of a resource collection.
+
+Same data shape as ``list`` (paginated, null-safe) but rendered as a
+responsive grid of Cards instead of a Table. Picks the first string field
+as the card title and the second as the description; remaining fields
+become a compact label/value list inside the card body. Enum and boolean
+fields render as Badges for visual scanning.
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case, title_case
+
+from .base import page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+def _pick_title_and_description(fields: list[dict]) -> tuple[dict | None, dict | None, list[dict]]:
+    """Pick which fields become CardTitle / CardDescription / body rows.
+
+    Heuristic: first ``string`` field is the title, second is the description.
+    Everything else (plus non-string fields) goes into the card body.
+    """
+    string_fields = [f for f in fields if f.get("type", "string") == "string"]
+    title = string_fields[0] if string_fields else None
+    description = string_fields[1] if len(string_fields) >= 2 else None
+    chosen = {id(title), id(description)} - {id(None)}
+    body = [f for f in fields if id(f) not in chosen]
+    return title, description, body
+
+
+def _render_body_value(field: dict, ui: bool) -> str:
+    """JSX expression for a single body field's value, type-aware and null-safe."""
+    fname = camel_case(field["name"])
+    ft = field.get("type", "string")
+
+    if ft == "boolean":
+        if ui:
+            return (
+                f"p.{fname} == null ? (\n"
+                f'                    <span className="text-muted-foreground">—</span>\n'
+                f"                  ) : p.{fname} ? (\n"
+                f'                    <Badge variant="default">{{t("yes")}}</Badge>\n'
+                f"                  ) : (\n"
+                f'                    <Badge variant="outline">{{t("no")}}</Badge>\n'
+                f"                  )"
+            )
+        return f'p.{fname} == null ? "—" : p.{fname} ? t("yes") : t("no")'
+
+    if ft == "decimal":
+        return f'p.{fname} != null ? `$${{p.{fname}.toFixed(2)}}` : "—"'
+
+    if ft in ("date", "datetime"):
+        return f'p.{fname} ? new Date(p.{fname}).toLocaleDateString() : "—"'
+
+    if ft == "enum" and ui:
+        return (
+            f"p.{fname} == null ? (\n"
+            f'                    <span className="text-muted-foreground">—</span>\n'
+            f"                  ) : (\n"
+            f'                    <Badge variant="secondary">{{String(p.{fname})}}</Badge>\n'
+            f"                  )"
+        )
+
+    return f'p.{fname} ?? "—"'
+
+
+def emit_grid(page: dict, ctx: PageContext) -> None:
+    """Generate a grid page — responsive card-grid for a resource collection."""
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    title_field, description_field, body_fields = _pick_title_and_description(fields)
+
+    # ui-kit imports
+    if ui:
+        ui_import = (
+            f'import {{ Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Badge }} from "{ui}";\n'
+        )
+    else:
+        ui_import = ""
+
+    # Build the card JSX
+    if title_field:
+        title_fname = camel_case(title_field["name"])
+        title_expr = f"{{p.{title_fname} ?? p.id}}"
+    else:
+        title_expr = "{p.id}"
+
+    if description_field:
+        desc_fname = camel_case(description_field["name"])
+        description_jsx = (
+            "              <CardDescription>\n"
+            f"                {{p.{desc_fname} ?? null}}\n"
+            "              </CardDescription>\n"
+            if ui
+            else f'              <p className="text-sm text-muted-foreground">{{p.{desc_fname} ?? null}}</p>\n'
+        )
+    else:
+        description_jsx = ""
+
+    # Body rows — one entry per remaining field
+    body_rows: list[str] = []
+    for f in body_fields:
+        flabel = title_case(f["name"])
+        value_expr = _render_body_value(f, bool(ui))
+        body_rows.append(
+            f'                <div className="flex items-start justify-between gap-2 text-sm">\n'
+            f'                  <dt className="text-muted-foreground">{flabel}</dt>\n'
+            f"                  <dd>\n"
+            f"                    {{{value_expr}}}\n"
+            f"                  </dd>\n"
+            f"                </div>"
+        )
+    body_rows_str = "\n".join(body_rows)
+
+    if ui:
+        card_block = (
+            f"            <Card key={{p.id}}>\n"
+            f"              <CardHeader>\n"
+            f"                <CardTitle>{title_expr}</CardTitle>\n"
+            f"{description_jsx}"
+            f"              </CardHeader>\n"
+            + (
+                f"              <CardContent>\n"
+                f'                <dl className="space-y-2">\n'
+                f"{body_rows_str}\n"
+                f"                </dl>\n"
+                f"              </CardContent>\n"
+                if body_rows
+                else ""
+            )
+            + "            </Card>"
+        )
+        empty_state = (
+            '          <p className="col-span-full text-center text-muted-foreground py-8">{t("noDataFound")}</p>'
+        )
+        btn_prev = (
+            '<Button variant="outline" size="sm" onClick={() => setPage(p => p - 1)} '
+            'disabled={page === 0}>{t("previous")}</Button>'
+        )
+        btn_next = (
+            '<Button variant="outline" size="sm" onClick={() => setPage(p => p + 1)} '
+            'disabled={page >= totalPages - 1}>{t("next")}</Button>'
+        )
+    else:
+        card_block = (
+            f'            <div key={{p.id}} className="rounded-lg border bg-card p-4 space-y-2">\n'
+            f'              <h3 className="text-lg font-semibold">{title_expr}</h3>\n'
+            f"{description_jsx}"
+            + (
+                f'              <dl className="space-y-1 pt-2 border-t">\n{body_rows_str}\n              </dl>\n'
+                if body_rows
+                else ""
+            )
+            + "            </div>"
+        )
+        empty_state = (
+            '          <p className="col-span-full text-center text-muted-foreground py-8">{t("noDataFound")}</p>'
+        )
+        btn_prev = (
+            '<button className="px-3 py-1 border rounded text-sm disabled:opacity-50" '
+            'onClick={() => setPage(p => p - 1)} disabled={page === 0}>{t("previous")}</button>'
+        )
+        btn_next = (
+            '<button className="px-3 py-1 border rounded text-sm disabled:opacity-50" '
+            'onClick={() => setPage(p => p + 1)} disabled={page >= totalPages - 1}>{t("next")}</button>'
+        )
+
+    dest.write_text(
+        f'import {{ useState }} from "react";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ useQuery }} from "@tanstack/react-query";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ {entity}, PageResponse }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f"  const [page, setPage] = useState(0);\n"
+        f"\n"
+        f"  const {{ data, isLoading, error }} = useQuery<PageResponse<{entity}>>({{  \n"
+        f'    queryKey: ["{resource}", "grid", page],\n'
+        f'    queryFn: () => api.get<PageResponse<{entity}>>("/{resource}", '
+        f'{{ params: {{ page: String(page), size: "20" }} }}),\n'
+        f"  }});\n"
+        f"\n"
+        f'  if (isLoading) return <p className="text-muted-foreground">{{t("loading")}}</p>;\n'
+        f'  if (error) return <p className="text-destructive">'
+        f'{{t("failedToLoad")}}: {{(error as Error).message}}</p>;\n'
+        f"\n"
+        f"  const items = data?.content ?? [];\n"
+        f"  const totalPages = data?.totalPages ?? 0;\n"
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f'      <div className="flex items-center justify-between">\n'
+        f'        <h1 className="text-2xl font-bold tracking-tight">'
+        f"{label} ({{data?.totalElements ?? 0}})</h1>\n"
+        f"      </div>\n"
+        f'      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">\n'
+        f"          {{items.map((p) => (\n"
+        f"{card_block}\n"
+        f"          ))}}\n"
+        f"          {{items.length === 0 && (\n"
+        f"{empty_state}\n"
+        f"          )}}\n"
+        f"      </div>\n"
+        f'      <div className="flex items-center justify-center gap-2" '
+        f'style={{{{ paddingTop: "1.5rem" }}}}>\n'
+        f"        {btn_prev}\n"
+        f'        <span className="text-sm text-muted-foreground">'
+        f"Page {{page + 1}} of {{totalPages}}</span>\n"
+        f"        {btn_next}\n"
+        f"      </div>\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="grid",
+    description="Responsive card-grid view for a resource collection.",
+    emit=emit_grid,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/tests/test_page_types_grid.py
+++ b/tests/test_page_types_grid.py
@@ -1,0 +1,175 @@
+"""Tests for the ``grid`` page type — card-grid view of a resource collection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_grid_type_is_registered() -> None:
+    info = get_registry().get("grid")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description
+
+
+# ── Emitter output ─────────────────────────────────────────────────────────
+
+
+def _generate_employee_grid(tmp_path: Path, *, uikit: str = "my-ui") -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "team",
+        "label": "Team Members",
+        "resource": "employee",
+        "type": "grid",
+        "fields": [
+            {"name": "firstName", "type": "string"},
+            {"name": "lastName", "type": "string"},
+            {"name": "email", "type": "string"},
+            {"name": "hireDate", "type": "date"},
+            {"name": "salary", "type": "decimal"},
+            {"name": "active", "type": "boolean"},
+            {"name": "status", "type": "enum", "values": ["active", "inactive"]},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "TeamPage.tsx").read_text()
+
+
+def test_grid_uses_paginated_query(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path)
+    assert "useQuery<PageResponse<Employee>>" in tsx
+    assert '"/employee"' in tsx
+    assert 'size: "20"' in tsx
+    # Separate queryKey from the list page so caches don't collide
+    assert '"employee", "grid", page' in tsx
+
+
+def test_grid_uses_responsive_grid_container(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path)
+    # 1 col mobile -> 2 md -> 3 lg is the canonical shadcn dashboard grid
+    assert "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" in tsx
+    assert "gap-4" in tsx
+
+
+def test_grid_renders_cards_with_title_and_description(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path)
+    # First string field becomes CardTitle, second becomes CardDescription
+    assert "<CardTitle>{p.firstName ?? p.id}</CardTitle>" in tsx
+    assert "<CardDescription>" in tsx
+    assert "{p.lastName ?? null}" in tsx
+
+
+def test_grid_body_skips_title_and_description_fields(tmp_path: Path) -> None:
+    """firstName and lastName are consumed by title/description; shouldn't reappear in body."""
+    tsx = _generate_employee_grid(tmp_path)
+    # Each body row emits `<dt>{label}</dt>` — check neither of the promoted fields is in one
+    assert ">First Name<" not in tsx
+    assert ">Last Name<" not in tsx
+    # But remaining fields are rendered as <dt> labels
+    for expected in ["Email", "Hire Date", "Salary", "Active", "Status"]:
+        assert f">{expected}<" in tsx, f"missing dt label: {expected!r}"
+
+
+def test_grid_formats_types_correctly(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path)
+    assert "p.salary.toFixed(2)" in tsx
+    assert "new Date(p.hireDate).toLocaleDateString()" in tsx
+    assert 't("yes")' in tsx
+    assert 't("no")' in tsx
+
+
+def test_grid_uikit_uses_badges_for_enum_and_boolean(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path, uikit="my-ui")
+    assert '<Badge variant="secondary">' in tsx
+    assert '<Badge variant="default">' in tsx
+    assert '<Badge variant="outline">' in tsx
+
+
+def test_grid_uikit_imports_card_and_badge(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path, uikit="my-ui")
+    assert 'from "my-ui"' in tsx
+    for sym in ["Card", "CardContent", "CardHeader", "CardTitle", "CardDescription", "Badge", "Button"]:
+        assert sym in tsx, f"missing ui-kit import: {sym}"
+
+
+def test_grid_pagination_controls(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path)
+    assert 't("previous")' in tsx
+    assert 't("next")' in tsx
+    assert "page === 0" in tsx  # previous disabled at page 0
+    assert "page >= totalPages - 1" in tsx  # next disabled at last page
+
+
+def test_grid_shows_empty_state_spanning_grid_columns(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path)
+    assert "col-span-full" in tsx
+    assert 't("noDataFound")' in tsx
+
+
+# ── Plain-HTML fallback ────────────────────────────────────────────────────
+
+
+def test_grid_plain_branch_uses_raw_divs(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path, uikit="")
+    # No ui-kit imports
+    assert 'from ""' not in tsx  # defensive: never emit empty import path
+    assert "Card" not in tsx
+    assert "Badge" not in tsx
+    # But the responsive grid container is still there
+    assert "grid-cols-1 md:grid-cols-2 lg:grid-cols-3" in tsx
+    # And the card-like divs use matching Tailwind classes
+    assert "rounded-lg border bg-card p-4" in tsx
+
+
+def test_grid_plain_branch_boolean_uses_t_helper(tmp_path: Path) -> None:
+    tsx = _generate_employee_grid(tmp_path, uikit="")
+    assert 't("yes")' in tsx
+    assert 't("no")' in tsx
+
+
+# ── Single-string-field edge case ──────────────────────────────────────────
+
+
+def test_grid_with_only_one_string_field_has_no_description(tmp_path: Path) -> None:
+    """When there's only one string field, title is set but description is omitted."""
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "things",
+        "label": "Things",
+        "resource": "thing",
+        "type": "grid",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "count", "type": "integer"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+    )
+    tsx = (project_root / "src" / "routes" / "ThingsPage.tsx").read_text()
+    assert "<CardTitle>{p.name ?? p.id}</CardTitle>" in tsx
+    assert "<CardDescription>" not in tsx
+    # And `count` (non-string) drops into the card body
+    assert ">Count<" in tsx


### PR DESCRIPTION
## Summary

Second Phase 2 page type: **`grid`** — responsive card-grid view. Same paginated data shape as `list`, but rendered as a 1/2/3-column grid of Cards instead of a Table. Matches SmartHR-style "Employee Grid" / "Candidates Grid" layouts.

## What the generator emits

- Responsive grid container: `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`
- Each record becomes a shadcn `<Card>`:
  - First `string` field → `<CardTitle>`
  - Second `string` field → `<CardDescription>` (omitted if only one string field exists)
  - Remaining fields → compact `<dl>` label/value rows in `<CardContent>`
- **Type-aware body values** (consistent with `list` / `detail`):

| Field type | Rendered as |
|---|---|
| `decimal` | `$NNN.NN` via `toFixed(2)` |
| `date` / `datetime` | `toLocaleDateString()` |
| `boolean` | `<Badge variant="default">Yes</Badge>` / `<Badge variant="outline">No</Badge>` |
| `enum` | `<Badge variant="secondary">value</Badge>` |
| else | plain text, null → `—` |

- Pagination controls identical to `list` (previous/next, 20/page)
- Empty-state message spans all grid columns (`col-span-full`)
- Separate `queryKey: ["{resource}", "grid", page]` so `list` + `grid` don't share a cached page when both are registered

Plain-HTML fallback (no `--uikit`) renders matching structure with raw `<div>/<h3>/<dl>` and Tailwind classes.

## Test plan

- [x] 13 new tests in `tests/test_page_types_grid.py`:
  - Registration + metadata
  - Paginated useQuery hook with grid-scoped queryKey
  - Responsive grid container classes
  - Title/description promotion from first two string fields
  - Promoted fields don't duplicate in the body
  - Type-specific formatters (decimal/date/boolean)
  - ui-kit Badge usage (all three variants)
  - Full ui-kit import list
  - Pagination controls + disabled-at-boundaries logic
  - Empty state with `col-span-full`
  - Plain-HTML fallback (no shadcn imports, matching Tailwind)
  - Plain-HTML boolean fallback uses `t("yes")/t("no")`
  - Single-string-field edge case (no `CardDescription`)
- [x] **Full suite: 142/142 passing** (129 pre-existing + 13 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated a ui-kit + api-client + frontend-app with a grid page; `vite build` succeeds.

## Docs

- `CLAUDE.md` — added `grid` entry under **Page types**, extended the `pages/` tree
- `README.md` — example `pages=[...]` now includes a `catalog` grid page

## Phase 2 progress

2/7 new page types landed: ~~`detail`~~ ✅ · ~~`grid`~~ ✅ · `edit` · `settings` · `tree` · `kanban` · `calendar`
