### PR TITLE
feat(pages): add `edit` page type — hydrated update form + destructive delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `dashboard` — stat cards + bar chart (Recharts) + recent items table
 - `detail` — read-only single-record view as a definition list inside a Card. Reads `id` from `?id=` query string, fetches `GET /{resource}/{id}` via useQuery. Type-aware value rendering: decimal → `toFixed(2)`, date/datetime → `toLocaleDateString()`, boolean → Badge ("Yes"/"No"), enum → Badge with value, text → `whitespace-pre-wrap`. Shows a Skeleton placeholder per field while loading; falls back to `t("missingId")` when `id` is absent.
 - `grid` — responsive card-grid (1 col mobile / 2 md / 3 lg) for a resource collection. Same paginated query as `list`. First string field becomes the CardTitle, second becomes CardDescription; remaining fields drop into the card body as label/value pairs. Enum and boolean values render as Badges for fast visual scanning. Null-safe, shows empty state spanning all grid columns.
+- `edit` — update form for an existing record. Reads `id` from `?id=` query string, fetches via `useQuery`, hydrates form state via `useEffect`, saves via PUT with `t("updatedSuccessfully")` feedback. Includes a destructive Delete button wrapped in an `AlertDialog` confirmation (Phase 0 component); plain-HTML fallback uses `window.confirm`. Same type-aware inputs and resource-lookup auto-detection as `form`.
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -191,7 +192,8 @@ src/apps_generator/
 │       │   ├── form_type.py
 │       │   ├── dashboard_type.py
 │       │   ├── detail_type.py
-│       │   └── grid_type.py
+│       │   ├── grid_type.py
+│       │   └── edit_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -237,7 +239,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard/detail/grid) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail/grid/edit) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ appgen generate api-domain -o ./product-service \
   -s 'resources=[{"name":"product","fields":[{"name":"name","type":"string","required":true,"maxLength":255},{"name":"price","type":"decimal","required":true,"min":0},{"name":"status","type":"enum","required":true,"values":["active","inactive","archived"]},{"name":"active","type":"boolean"}]}]' \
   --gateway ./gateway --api-client ./api-client
 
-# 6. Micro-frontend with data-aware pages (dashboard + list + grid + form + detail)
+# 6. Micro-frontend with data-aware pages (dashboard + list + grid + form + detail + edit)
 appgen generate frontend-app -o ./products -s projectName=products -s devPort=5001 \
   -s 'pages=[
     {"path":"overview","label":"Overview","resource":"product","type":"dashboard","fields":[
@@ -59,6 +59,11 @@ appgen generate frontend-app -o ./products -s projectName=products -s devPort=50
       {"name":"description","type":"text"}
     ]},
     {"path":"create","label":"New Product","resource":"product","type":"form","fields":[
+      {"name":"name","type":"string","required":true},
+      {"name":"price","type":"decimal","required":true},
+      {"name":"description","type":"text"}
+    ]},
+    {"path":"edit","label":"Edit Product","resource":"product","type":"edit","fields":[
       {"name":"name","type":"string","required":true},
       {"name":"price","type":"decimal","required":true},
       {"name":"description","type":"text"}

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -28,7 +28,7 @@ from .registry import PageContext, PageTypeInfo, PageTypeRegistry, get_registry
 # ``list``) via the package-attribute binding that submodule imports trigger.
 # Adding a new built-in is as simple as dropping a ``<name>_type.py`` module
 # in this package.
-_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type", "detail_type", "grid_type")
+_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type", "detail_type", "grid_type", "edit_type")
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")
 

--- a/src/apps_generator/cli/generators/pages/edit_type.py
+++ b/src/apps_generator/cli/generators/pages/edit_type.py
@@ -1,0 +1,475 @@
+"""``edit`` page type — update form + delete confirmation for a single record.
+
+Mirrors ``form_type`` (same auto-detected lookups, same type-aware inputs)
+but adds three things:
+
+1. A :func:`useQuery` fetch of the existing record (id from ``?id=`` query
+   string, like ``detail_type``) and a :func:`useEffect` that seeds the
+   form state once the data lands.
+2. A PUT mutation that replaces the existing record, with
+   ``t("updatedSuccessfully")`` feedback.
+3. A destructive Delete button wrapped in an :component:`AlertDialog` —
+   confirmation step, then DELETE, then ``history.back()`` to return to
+   whatever referred the user here.
+
+The field-input rendering is duplicated from ``form_type`` for now. A
+follow-up could extract it into :mod:`.base` so both emitters share a
+single source of truth — deferred to keep this PR focused.
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case, title_case
+
+from .base import detect_lookup, page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+def emit_edit(page: dict, ctx: PageContext) -> None:
+    """Generate an edit page — hydrated form + PUT + delete with confirm."""
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+
+    # Auto-detect lookups (same convention as form_type, mutating fields in
+    # place to preserve the existing contract).
+    if ctx.all_resources:
+        other_resources = [r for r in ctx.all_resources if r != resource]
+        for f in fields:
+            if "lookup" not in f:
+                detected = detect_lookup(f, other_resources)
+                if detected:
+                    f["lookup"] = detected
+
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    # ui-kit imports — edit needs Form primitives + AlertDialog for the
+    # destructive confirm flow. AlertDialog is a Phase 0 addition.
+    if ui:
+        ui_import = (
+            f"import {{ Button, Input, Label, Textarea, Checkbox, "
+            f"Card, CardContent, CardHeader, CardTitle, Alert, AlertDescription, "
+            f"AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, "
+            f"AlertDialogFooter, AlertDialogTitle, AlertDialogDescription, "
+            f'AlertDialogAction, AlertDialogCancel }} from "{ui}";\n'
+        )
+    else:
+        ui_import = ""
+
+    # Initial empty state — filled in by useEffect once the fetch resolves.
+    defaults: dict[str, str] = {}
+    for f in fields:
+        ft = f.get("type", "string")
+        fname = camel_case(f["name"])
+        if ft == "boolean":
+            defaults[fname] = "false"
+        else:
+            defaults[fname] = '""'
+    state_init = ", ".join(f"{k}: {v}" for k, v in defaults.items())
+
+    # State hydration — map each fetched field into the form. Numbers come
+    # back as numbers from the API but the form state expects strings.
+    hydrate_lines: list[str] = []
+    for f in fields:
+        ft = f.get("type", "string")
+        fname = camel_case(f["name"])
+        if ft == "boolean":
+            hydrate_lines.append(f"          {fname}: data.{fname} ?? false,")
+        elif ft in ("integer", "long", "decimal"):
+            hydrate_lines.append(f'          {fname}: data.{fname} != null ? String(data.{fname}) : "",')
+        elif ft == "datetime":
+            # HTML datetime-local wants YYYY-MM-DDTHH:mm (no TZ) — trim any zone.
+            hydrate_lines.append(f'          {fname}: data.{fname} ? String(data.{fname}).slice(0, 16) : "",')
+        else:
+            hydrate_lines.append(f'          {fname}: data.{fname} ?? "",')
+    hydrate_str = "\n".join(hydrate_lines)
+
+    # Collect lookups for the extra useQuery hooks (same as form_type).
+    lookups: list[dict] = []
+    for f in fields:
+        if "lookup" in f:
+            lk = f["lookup"]
+            if lk not in lookups:
+                lookups.append(lk)
+
+    # Build the form inputs — duplicated from form_type for now.
+    inputs: list[str] = []
+    for f in fields:
+        ft = f.get("type", "string")
+        fname = camel_case(f["name"])
+        flabel = title_case(f["name"])
+        required = f.get("required", False)
+        req_star = " *" if required else ""
+        lookup = f.get("lookup")
+
+        if ui:
+            if lookup:
+                lk_res = lookup["resource"]
+                lk_var = camel_case(lk_res) + "Options"
+                lk_val = lookup.get("valueField", "name")
+                lk_label = lookup.get("labelField", "name")
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f"          {{{lk_var}.length === 0 ? (\n"
+                    f'            <p className="text-sm text-muted-foreground">No {title_case(lk_res)}s found. <a href="../{lk_res}s/new" className="underline text-primary">Create one first</a>.</p>\n'
+                    f"          ) : (\n"
+                    f'            <select id="{fname}" className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"\n'
+                    f"              value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                    f'              <option value="">Select {flabel}...</option>\n'
+                    f"              {{{lk_var}.map((opt: any) => <option key={{opt.{lk_val}}} value={{opt.{lk_val}}}>{{opt.{lk_label}}}</option>)}}\n"
+                    f"            </select>\n"
+                    f"          )}}\n"
+                    f"        </div>"
+                )
+                continue
+
+            if ft == "text":
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <Textarea id="{fname}" rows={{3}}\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "boolean":
+                inputs.append(
+                    f'        <div className="flex items-center space-x-2">\n'
+                    f'          <Checkbox id="{fname}" checked={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: (e.target as HTMLInputElement).checked}}))}}/>\n'
+                    f'          <Label htmlFor="{fname}">{flabel}</Label>\n'
+                    f"        </div>"
+                )
+            elif ft == "date":
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <Input id="{fname}" type="date"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "datetime":
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <Input id="{fname}" type="datetime-local"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+            elif ft in ("integer", "long"):
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <Input id="{fname}" type="number"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "decimal":
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <Input id="{fname}" type="number" step="0.01"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "enum" and f.get("values"):
+                options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <select id="{fname}" className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                    f'              <option value="">Select {flabel}...</option>{options}\n'
+                    f"            </select>\n"
+                    f"        </div>"
+                )
+            else:
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f'          <Input id="{fname}" type="text"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+        else:
+            # Plain-HTML fallback
+            if lookup:
+                lk_res = lookup["resource"]
+                lk_var = camel_case(lk_res) + "Options"
+                lk_val = lookup.get("valueField", "name")
+                lk_label = lookup.get("labelField", "name")
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f"          {{{lk_var}.length === 0 ? (\n"
+                    f'            <p className="mt-1 text-sm text-muted-foreground">No {title_case(lk_res)}s found. <a href="../{lk_res}s/new" className="underline">Create one first</a>.</p>\n'
+                    f"          ) : (\n"
+                    f'            <select id="{fname}" className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"\n'
+                    f"              value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                    f'              <option value="">Select {flabel}...</option>\n'
+                    f"              {{{lk_var}.map((opt: any) => <option key={{opt.{lk_val}}} value={{opt.{lk_val}}}>{{opt.{lk_label}}}</option>)}}\n"
+                    f"            </select>\n"
+                    f"          )}}\n"
+                    f"        </div>"
+                )
+                continue
+            if ft == "text":
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f'          <textarea id="{fname}" className="mt-1 flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm" rows={{3}}\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "boolean":
+                inputs.append(
+                    f'        <div className="flex items-center space-x-2">\n'
+                    f'          <input id="{fname}" type="checkbox" className="h-4 w-4 rounded border-primary" checked={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.checked}}))}}/>\n'
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}</label>\n'
+                    f"        </div>"
+                )
+            elif ft == "enum" and f.get("values"):
+                options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f'          <select id="{fname}" className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                    f'              <option value="">Select {flabel}...</option>{options}\n'
+                    f"            </select>\n"
+                    f"        </div>"
+                )
+            else:
+                input_type = (
+                    "number"
+                    if ft in ("integer", "long", "decimal")
+                    else "date"
+                    if ft == "date"
+                    else "datetime-local"
+                    if ft == "datetime"
+                    else "text"
+                )
+                step = ' step="0.01"' if ft == "decimal" else ""
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f'          <input id="{fname}" type="{input_type}"{step} className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                    f"        </div>"
+                )
+
+    inputs_str = "\n".join(inputs)
+
+    # Body of the PUT — cast numeric fields back to numbers.
+    body_fields: list[str] = []
+    for f in fields:
+        ft = f.get("type", "string")
+        fname = camel_case(f["name"])
+        if ft in ("integer", "long", "decimal"):
+            body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
+        elif ft == "boolean":
+            body_fields.append(f"        {fname}: form.{fname},")
+        else:
+            body_fields.append(f"        {fname}: form.{fname} || undefined,")
+    body_str = "\n".join(body_fields)
+
+    # Action buttons — Save + destructive Delete with AlertDialog.
+    if ui:
+        save_btn = (
+            '            <Button type="submit" disabled={update.isPending}>\n'
+            '              {update.isPending ? t("saving") : t("save")}\n'
+            "            </Button>"
+        )
+        delete_trigger_wrap = (
+            "            <AlertDialog>\n"
+            "              <AlertDialogTrigger asChild>\n"
+            '                <Button type="button" variant="destructive" disabled={del_.isPending}>\n'
+            '                  {del_.isPending ? t("deleting") : t("delete")}\n'
+            "                </Button>\n"
+            "              </AlertDialogTrigger>\n"
+            "              <AlertDialogContent>\n"
+            "                <AlertDialogHeader>\n"
+            '                  <AlertDialogTitle>{t("confirmDelete")}</AlertDialogTitle>\n'
+            '                  <AlertDialogDescription>{t("confirmDeleteDesc")}</AlertDialogDescription>\n'
+            "                </AlertDialogHeader>\n"
+            "                <AlertDialogFooter>\n"
+            '                  <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>\n'
+            '                  <AlertDialogAction onClick={() => del_.mutate()}>{t("confirm")}</AlertDialogAction>\n'
+            "                </AlertDialogFooter>\n"
+            "              </AlertDialogContent>\n"
+            "            </AlertDialog>"
+        )
+        action_row = (
+            '          <div className="flex gap-2" style={{ paddingTop: "1.5rem" }}>\n'
+            f"{save_btn}\n"
+            f"{delete_trigger_wrap}\n"
+            "          </div>"
+        )
+        # Note: ``{{{{`` in an f-string becomes ``{{`` in the emitted .tsx —
+        # that's the JSX style-prop double-brace. The emitted file is not
+        # Jinja-rendered so the literal ``{{`` is safe.
+        success_msg = (
+            '          {success && <Alert className="mb-2">'
+            '<AlertDescription>{t("updatedSuccessfully")}</AlertDescription></Alert>}'
+        )
+        error_msg = (
+            "          {(update.error || del_.error) && "
+            '<Alert variant="destructive" className="mb-2"><AlertDescription>'
+            "{((update.error || del_.error) as Error).message}</AlertDescription></Alert>}"
+        )
+        form_open = (
+            f'      <Card className="max-w-xl">\n'
+            f"        <CardHeader>\n"
+            f"          <CardTitle>{label}</CardTitle>\n"
+            f"        </CardHeader>\n"
+            f"        <CardContent>\n"
+            f"{success_msg}\n"
+            f"{error_msg}\n"
+            f'          <form onSubmit={{handleSubmit}} className="space-y-4">'
+        )
+        form_close = f"{action_row}\n          </form>\n        </CardContent>\n      </Card>"
+    else:
+        save_btn = (
+            '            <button type="submit" disabled={update.isPending}\n'
+            '              className="inline-flex items-center justify-center rounded-md '
+            "text-sm font-medium bg-primary text-primary-foreground h-10 px-4 py-2 "
+            'hover:bg-primary/90 disabled:opacity-50">\n'
+            '              {update.isPending ? t("saving") : t("save")}\n'
+            "            </button>"
+        )
+        delete_trigger_wrap = (
+            '            <button type="button" disabled={del_.isPending}\n'
+            '              onClick={() => { if (confirm(t("confirmDelete"))) del_.mutate(); }}\n'
+            '              className="inline-flex items-center justify-center rounded-md '
+            "text-sm font-medium bg-destructive text-destructive-foreground h-10 px-4 py-2 "
+            'hover:bg-destructive/90 disabled:opacity-50">\n'
+            '              {del_.isPending ? t("deleting") : t("delete")}\n'
+            "            </button>"
+        )
+        action_row = (
+            '          <div className="flex gap-2" style={{ paddingTop: "1.5rem" }}>\n'
+            f"{save_btn}\n"
+            f"{delete_trigger_wrap}\n"
+            "          </div>"
+        )
+        success_msg = (
+            '          {success && <div className="mb-2 p-3 rounded-md border bg-green-50 text-green-800 text-sm">'
+            '{t("updatedSuccessfully")}</div>}'
+        )
+        error_msg = (
+            "          {(update.error || del_.error) && "
+            '<div className="mb-2 p-3 rounded-md border border-destructive/50 '
+            'bg-destructive/5 text-destructive text-sm">'
+            "{((update.error || del_.error) as Error).message}</div>}"
+        )
+        form_open = (
+            f'      <h1 className="text-2xl font-bold tracking-tight mb-4">{label}</h1>\n'
+            f"{success_msg}\n"
+            f"{error_msg}\n"
+            f'      <form onSubmit={{handleSubmit}} className="max-w-xl space-y-6">'
+        )
+        form_close = f"{action_row}\n      </form>"
+
+    # Lookup query hooks (same as form_type)
+    lookup_hooks = ""
+    rq_imports = "useQuery, useMutation, useQueryClient"
+    if lookups:
+        for lk in lookups:
+            lk_res = lk["resource"]
+            lk_entity = pascal_case(lk_res)
+            lk_var = camel_case(lk_res) + "Options"
+            lookup_hooks += (
+                f"\n"
+                f"  const {{ data: {lk_var}Data }} = useQuery<{{ content: {lk_entity}[] }}>({{  \n"
+                f'    queryKey: ["{lk_res}", "all"],\n'
+                f'    queryFn: () => api.get("/{lk_res}", {{ params: {{ size: "100" }} }}),\n'
+                f"  }});\n"
+                f"  const {lk_var} = {lk_var}Data?.content ?? [];\n"
+            )
+
+    lookup_type_imports = ""
+    for lk in lookups:
+        lk_entity = pascal_case(lk["resource"])
+        lookup_type_imports += f", {lk_entity}"
+
+    dest.write_text(
+        f'import {{ useState, useEffect }} from "react";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ {rq_imports} }} from "@tanstack/react-query";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ Update{entity}Request, {entity}{lookup_type_imports} }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f"  const queryClient = useQueryClient();\n"
+        f'  const id = new URLSearchParams(window.location.search).get("id");\n'
+        f"  const [form, setForm] = useState({{ {state_init} }});\n"
+        f"  const [success, setSuccess] = useState(false);\n"
+        f"\n"
+        f"  const {{ data: existing, isLoading, error: fetchError }} = useQuery<{entity}>({{  \n"
+        f'    queryKey: ["{resource}", id],\n'
+        f"    queryFn: () => api.get<{entity}>(`/{resource}/${{id}}`),\n"
+        f"    enabled: !!id,\n"
+        f"  }});\n"
+        f"\n"
+        f"  useEffect(() => {{\n"
+        f"    if (existing) {{\n"
+        f"      setForm({{\n"
+        f"{hydrate_str}\n"
+        f"      }});\n"
+        f"    }}\n"
+        f"  }}, [existing]);\n"
+        f"{lookup_hooks}"
+        f"\n"
+        f"  const update = useMutation({{\n"
+        f"    mutationFn: (data: Update{entity}Request) =>\n"
+        f"      api.put<{entity}>(`/{resource}/${{id}}`, data),\n"
+        f"    onSuccess: () => {{\n"
+        f'      queryClient.invalidateQueries({{ queryKey: ["{resource}"] }});\n'
+        f"      setSuccess(true);\n"
+        f"      setTimeout(() => setSuccess(false), 3000);\n"
+        f"    }},\n"
+        f"  }});\n"
+        f"\n"
+        f"  const del_ = useMutation({{\n"
+        f"    mutationFn: () => api.delete<void>(`/{resource}/${{id}}`),\n"
+        f"    onSuccess: () => {{\n"
+        f'      queryClient.invalidateQueries({{ queryKey: ["{resource}"] }});\n'
+        f"      window.history.back();\n"
+        f"    }},\n"
+        f"  }});\n"
+        f"\n"
+        f"  const handleSubmit = (e: React.FormEvent) => {{\n"
+        f"    e.preventDefault();\n"
+        f"    update.mutate({{\n"
+        f"{body_str}\n"
+        f"    }} as Update{entity}Request);\n"
+        f"  }};\n"
+        f"\n"
+        f'  if (!id) return <p className="text-destructive">{{t("missingId")}}</p>;\n'
+        f'  if (isLoading) return <p className="text-muted-foreground">{{t("loading")}}</p>;\n'
+        f"  if (fetchError)\n"
+        f'    return <p className="text-destructive">{{t("failedToLoad")}}: {{(fetchError as Error).message}}</p>;\n'
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f"{form_open}\n"
+        f"{inputs_str}\n"
+        f"{form_close}\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="edit",
+    description="Edit form for an existing record — hydrated from GET, saves via PUT, with a destructive delete confirmation.",
+    emit=emit_edit,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/en.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/en.json
@@ -18,5 +18,14 @@
   "createdSuccessfully": "Created successfully!",
   "yes": "Yes",
   "no": "No",
-  "missingId": "No ID provided"
+  "missingId": "No ID provided",
+  "save": "Save",
+  "saving": "Saving...",
+  "updatedSuccessfully": "Updated successfully!",
+  "delete": "Delete",
+  "deleting": "Deleting...",
+  "confirmDelete": "Are you sure?",
+  "confirmDeleteDesc": "This action cannot be undone.",
+  "confirm": "Confirm",
+  "cancel": "Cancel"
 }

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/fr.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/fr.json
@@ -18,5 +18,14 @@
   "createdSuccessfully": "Créé avec succès !",
   "yes": "Oui",
   "no": "Non",
-  "missingId": "Aucun ID fourni"
+  "missingId": "Aucun ID fourni",
+  "save": "Enregistrer",
+  "saving": "Enregistrement...",
+  "updatedSuccessfully": "Mis à jour avec succès !",
+  "delete": "Supprimer",
+  "deleting": "Suppression...",
+  "confirmDelete": "Êtes-vous sûr ?",
+  "confirmDeleteDesc": "Cette action est irréversible.",
+  "confirm": "Confirmer",
+  "cancel": "Annuler"
 }

--- a/tests/test_page_types_edit.py
+++ b/tests/test_page_types_edit.py
@@ -1,0 +1,206 @@
+"""Tests for the ``edit`` page type — update form + delete confirmation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_edit_type_is_registered() -> None:
+    info = get_registry().get("edit")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description
+
+
+# ── Emitter fixture ────────────────────────────────────────────────────────
+
+
+def _generate_employee_edit(tmp_path: Path, *, uikit: str = "my-ui") -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "edit",
+        "label": "Edit Employee",
+        "resource": "employee",
+        "type": "edit",
+        "fields": [
+            {"name": "firstName", "type": "string", "required": True},
+            {"name": "email", "type": "string"},
+            {"name": "hireDate", "type": "date"},
+            {"name": "startTime", "type": "datetime"},
+            {"name": "salary", "type": "decimal"},
+            {"name": "yearsExperience", "type": "integer"},
+            {"name": "active", "type": "boolean"},
+            {"name": "status", "type": "enum", "values": ["active", "inactive"]},
+            {"name": "notes", "type": "text"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "EditPage.tsx").read_text()
+
+
+# ── Fetch + hydrate ────────────────────────────────────────────────────────
+
+
+def test_edit_reads_id_from_query_string(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert 'new URLSearchParams(window.location.search).get("id")' in tsx
+    assert 't("missingId")' in tsx
+
+
+def test_edit_fetches_existing_via_use_query(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert "useQuery<Employee>" in tsx
+    assert "`/employee/${id}`" in tsx
+    assert "enabled: !!id" in tsx
+
+
+def test_edit_hydrates_form_state_from_fetched_record(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    # Numbers are stringified for the Input[type=number] controls
+    assert 'salary: data.salary != null ? String(data.salary) : "",' in tsx
+    assert 'yearsExperience: data.yearsExperience != null ? String(data.yearsExperience) : "",' in tsx
+    # Booleans fall back to false
+    assert "active: data.active ?? false," in tsx
+    # datetime is trimmed to the 16 chars the <input type=datetime-local> expects
+    assert 'startTime: data.startTime ? String(data.startTime).slice(0, 16) : "",' in tsx
+    # Strings fall back to ""
+    assert 'firstName: data.firstName ?? "",' in tsx
+    # And hydration fires in a useEffect so it waits for the fetch
+    assert "useEffect(() => {" in tsx
+
+
+# ── Mutations ──────────────────────────────────────────────────────────────
+
+
+def test_edit_uses_put_for_update(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert "api.put<Employee>(`/employee/${id}`, data)" in tsx
+    assert "UpdateEmployeeRequest" in tsx
+
+
+def test_edit_uses_delete_for_destructive_action(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert "api.delete<void>(`/employee/${id}`)" in tsx
+    # After delete we return to wherever the user came from
+    assert "window.history.back()" in tsx
+
+
+def test_edit_invalidates_resource_queries(tmp_path: Path) -> None:
+    """Both save and delete should invalidate the resource's cached queries."""
+    tsx = _generate_employee_edit(tmp_path)
+    assert tsx.count('queryClient.invalidateQueries({ queryKey: ["employee"] })') == 2
+
+
+def test_edit_shows_updated_success_and_merged_errors(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert 't("updatedSuccessfully")' in tsx
+    # A single error banner covers both mutations
+    assert "(update.error || del_.error)" in tsx
+
+
+# ── AlertDialog destructive confirm ────────────────────────────────────────
+
+
+def test_edit_uses_alert_dialog_for_delete_confirm(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path, uikit="my-ui")
+    for sym in [
+        "AlertDialog",
+        "AlertDialogTrigger",
+        "AlertDialogContent",
+        "AlertDialogHeader",
+        "AlertDialogFooter",
+        "AlertDialogTitle",
+        "AlertDialogDescription",
+        "AlertDialogAction",
+        "AlertDialogCancel",
+    ]:
+        assert sym in tsx, f"missing AlertDialog symbol: {sym}"
+    # Confirmation copy is i18n-keyed
+    assert 't("confirmDelete")' in tsx
+    assert 't("confirmDeleteDesc")' in tsx
+    # Cancel + Confirm buttons
+    assert 't("cancel")' in tsx
+    assert 't("confirm")' in tsx
+    # Confirm button actually triggers the mutation
+    assert "onClick={() => del_.mutate()}" in tsx
+
+
+def test_edit_plain_fallback_uses_confirm_prompt(tmp_path: Path) -> None:
+    """Without --uikit we can't use AlertDialog; fall back to window.confirm."""
+    tsx = _generate_employee_edit(tmp_path, uikit="")
+    assert "AlertDialog" not in tsx
+    assert 'confirm(t("confirmDelete"))' in tsx
+
+
+# ── Form inputs match form_type behaviour ──────────────────────────────────
+
+
+def test_edit_renders_type_aware_inputs(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    # Enum → <select> with the provided options
+    assert '<option value="active">Active</option>' in tsx
+    assert '<option value="inactive">Inactive</option>' in tsx
+    # Checkbox for boolean
+    assert '<Checkbox id="active"' in tsx
+    # Textarea for text
+    assert '<Textarea id="notes"' in tsx
+    # Dedicated date / datetime-local inputs
+    assert '<Input id="hireDate" type="date"' in tsx
+    assert '<Input id="startTime" type="datetime-local"' in tsx
+    # Number inputs for integer/decimal
+    assert '<Input id="yearsExperience" type="number"' in tsx
+    assert '<Input id="salary" type="number" step="0.01"' in tsx
+
+
+def test_edit_required_fields_show_star(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert "First Name *" in tsx
+    # Non-required fields don't get the star
+    assert ">Email<" in tsx or "Email</Label>" in tsx
+
+
+# ── Plain-HTML fallback ────────────────────────────────────────────────────
+
+
+def test_edit_plain_branch_has_no_shadcn_imports(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path, uikit="")
+    assert "Card" not in tsx
+    assert "AlertDialog" not in tsx
+
+
+# ── Loading / error states ─────────────────────────────────────────────────
+
+
+def test_edit_handles_fetch_loading_and_error(tmp_path: Path) -> None:
+    tsx = _generate_employee_edit(tmp_path)
+    assert 't("loading")' in tsx
+    assert 't("failedToLoad")' in tsx
+
+
+def test_edit_emits_valid_jsx_style_prop(tmp_path: Path) -> None:
+    """Regression: the inline style prop is one double-brace (object literal), not four.
+
+    An earlier version of the emitter over-escaped and wrote
+    ``style={{{{ paddingTop: ... }}}}`` which is invalid JSX and breaks
+    ``vite build``.
+    """
+    tsx = _generate_employee_edit(tmp_path)
+    assert "{{{{" not in tsx
+    assert "}}}}" not in tsx
+    assert 'style={{ paddingTop: "1.5rem" }}' in tsx


### PR DESCRIPTION
## Summary

Third Phase 2 page type — and the **first one to lean on a Phase 0 ui-kit addition** (`AlertDialog`). Closes the biggest single gap from the SmartHR skeleton audit: every resource now has a complete CRUD loop via `form` (create) + `detail` (read) + `edit` (update + delete).

## Behaviour

`edit` mirrors `form` (same type-aware inputs, same resource-lookup auto-detection) and layers on:

1. **`useQuery` fetch** of the existing record, using the `?id=` query string like `detail`
2. **`useEffect` hydration** of the form state when the fetch lands:
   - Numbers stringified (HTML `<input type="number">` wants strings)
   - Datetime values trimmed to 16 chars for `<input type="datetime-local">`
   - Booleans fall back to `false`, strings to `""`
3. **PUT mutation** (`api.put<Entity>(/{resource}/{id}, data)`) with `t("updatedSuccessfully")` feedback
4. **DELETE mutation** fronted by an `AlertDialog` confirm (Phase 0 component), returning via `window.history.back()` on success. Plain-HTML fallback uses `window.confirm`.

Both mutations invalidate the resource's cached queryKey so `list` and `grid` auto-refresh.

## i18n

Nine new keys in both `en.json` and `fr.json`:

| key | EN | FR |
|---|---|---|
| `save` | Save | Enregistrer |
| `saving` | Saving... | Enregistrement... |
| `updatedSuccessfully` | Updated successfully! | Mis à jour avec succès ! |
| `delete` | Delete | Supprimer |
| `deleting` | Deleting... | Suppression... |
| `confirmDelete` | Are you sure? | Êtes-vous sûr ? |
| `confirmDeleteDesc` | This action cannot be undone. | Cette action est irréversible. |
| `confirm` | Confirm | Confirmer |
| `cancel` | Cancel | Annuler |

## Test plan

- [x] 15 new tests in `tests/test_page_types_edit.py`:
  - Registration + metadata
  - `?id=` extraction + missingId fallback
  - `useQuery` fetch with `enabled: !!id`
  - Form-state hydration: stringification of numbers, datetime trim, boolean default, string default
  - PUT endpoint + `UpdateEntityRequest` type
  - DELETE endpoint + `window.history.back()`
  - Both mutations invalidate the resource queryKey
  - Single banner covers both `update.error` and `del_.error`
  - AlertDialog wiring: trigger, content, title, description, cancel, action → `del_.mutate()`
  - Plain-HTML fallback uses `window.confirm`
  - Type-aware inputs (text/checkbox/date/datetime/number/decimal/enum)
  - Required-field stars
  - Loading / fetch error states
  - **Regression guard**: inline style prop is a single JSX object literal (`{{ ... }}`), not over-escaped `{{{{ ... }}}}` — an earlier draft broke `vite build` with the over-escaped form
- [x] **Full suite: 157/157 passing** (142 pre-existing + 15 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated a full ui-kit + api-client + api-domain + frontend-app stack with an edit page; `vite build` succeeds.

## Docs

- `CLAUDE.md` — new `edit` entry under **Page types**; `pages/` tree extended
- `README.md` — example `pages=[...]` now includes an `edit` page

## Follow-up

The field-input rendering in `edit_type.py` is a direct copy of the equivalent block in `form_type.py`. Extracting into `base.py` is a reasonable next refactor but kept out of this PR to keep the diff focused on the new page type.

## Phase 2 progress

3/7 new page types landed: ~~`detail`~~ ✅ · ~~`grid`~~ ✅ · ~~`edit`~~ ✅ · `settings` · `tree` · `kanban` · `calendar`
