### PR TITLE
feat(pages): add `settings` page type — singleton config form with grouped sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `detail` — read-only single-record view as a definition list inside a Card. Reads `id` from `?id=` query string, fetches `GET /{resource}/{id}` via useQuery. Type-aware value rendering: decimal → `toFixed(2)`, date/datetime → `toLocaleDateString()`, boolean → Badge ("Yes"/"No"), enum → Badge with value, text → `whitespace-pre-wrap`. Shows a Skeleton placeholder per field while loading; falls back to `t("missingId")` when `id` is absent.
 - `grid` — responsive card-grid (1 col mobile / 2 md / 3 lg) for a resource collection. Same paginated query as `list`. First string field becomes the CardTitle, second becomes CardDescription; remaining fields drop into the card body as label/value pairs. Enum and boolean values render as Badges for fast visual scanning. Null-safe, shows empty state spanning all grid columns.
 - `edit` — update form for an existing record. Reads `id` from `?id=` query string, fetches via `useQuery`, hydrates form state via `useEffect`, saves via PUT with `t("updatedSuccessfully")` feedback. Includes a destructive Delete button wrapped in an `AlertDialog` confirmation (Phase 0 component); plain-HTML fallback uses `window.confirm`. Same type-aware inputs and resource-lookup auto-detection as `form`.
+- `settings` — configuration form for a **singleton** resource. `GET /{resource}` returns one record, `PUT /{resource}` updates it — no `id` in the URL. Fields can be grouped via an optional `group` key and render as shadcn `Accordion` items (Phase 0), all expanded by default; ungrouped fields drop into a "General" section. Plain-HTML fallback uses bordered `<section>` headings instead of Accordion. No delete.
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -193,7 +194,8 @@ src/apps_generator/
 │       │   ├── dashboard_type.py
 │       │   ├── detail_type.py
 │       │   ├── grid_type.py
-│       │   └── edit_type.py
+│       │   ├── edit_type.py
+│       │   └── settings_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -239,7 +241,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard/detail/grid/edit) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail/grid/edit/settings) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -28,7 +28,15 @@ from .registry import PageContext, PageTypeInfo, PageTypeRegistry, get_registry
 # ``list``) via the package-attribute binding that submodule imports trigger.
 # Adding a new built-in is as simple as dropping a ``<name>_type.py`` module
 # in this package.
-_BUILTIN_TYPES = ("list_type", "form_type", "dashboard_type", "detail_type", "grid_type", "edit_type")
+_BUILTIN_TYPES = (
+    "list_type",
+    "form_type",
+    "dashboard_type",
+    "detail_type",
+    "grid_type",
+    "edit_type",
+    "settings_type",
+)
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")
 

--- a/src/apps_generator/cli/generators/pages/settings_type.py
+++ b/src/apps_generator/cli/generators/pages/settings_type.py
@@ -1,0 +1,401 @@
+"""``settings`` page type — configuration form for a singleton resource.
+
+Unlike ``form`` / ``edit`` which operate on a collection (``/resource`` for
+listing, ``/resource/{id}`` for one record), ``settings`` treats the
+resource as a single record: ``GET /{resource}`` returns the one record,
+``PUT /{resource}`` replaces it. No ``id`` is needed in the URL.
+
+Fields can be grouped via an optional ``group`` key on each field. Groups
+render as shadcn ``Accordion`` items (all expanded by default), giving a
+familiar multi-section settings UX. Ungrouped fields drop into a
+"General" section.
+
+Example page config::
+
+    {
+      "path": "settings",
+      "label": "Organization Settings",
+      "resource": "orgSettings",
+      "type": "settings",
+      "fields": [
+        {"name": "companyName",  "type": "string",  "group": "Company"},
+        {"name": "billingEmail", "type": "string",  "group": "Billing"},
+        {"name": "autoRenew",    "type": "boolean", "group": "Billing"},
+        {"name": "maintenance",  "type": "boolean"}
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case, title_case
+
+from .base import page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+_DEFAULT_GROUP = "General"
+
+
+def _group_fields(fields: list[dict]) -> list[tuple[str, list[dict]]]:
+    """Bucket fields by their optional ``group`` key, preserving insertion order.
+
+    Returns a list of ``(group_label, fields)`` tuples. Ungrouped fields are
+    collected under :data:`_DEFAULT_GROUP`. Groups appear in the order they
+    first show up in the page config.
+    """
+    groups: dict[str, list[dict]] = {}
+    order: list[str] = []
+    for f in fields:
+        g = f.get("group") or _DEFAULT_GROUP
+        if g not in groups:
+            groups[g] = []
+            order.append(g)
+        groups[g].append(f)
+    return [(g, groups[g]) for g in order]
+
+
+def _render_input(field: dict, ui: bool) -> str:
+    """Return one labelled input block for a field.
+
+    Mirrors the rendering in ``form_type`` / ``edit_type`` for the supported
+    types (string, text, integer/long, decimal, date, datetime, boolean,
+    enum). ``settings`` doesn't participate in resource-lookup auto-detection
+    because it's a singleton record.
+    """
+    fname = camel_case(field["name"])
+    flabel = title_case(field["name"])
+    ft = field.get("type", "string")
+    required = field.get("required", False)
+    req_star = " *" if required else ""
+
+    if ui:
+        if ft == "text":
+            return (
+                f'        <div className="space-y-2">\n'
+                f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                f'          <Textarea id="{fname}" rows={{3}}\n'
+                f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                f"        </div>"
+            )
+        if ft == "boolean":
+            return (
+                f'        <div className="flex items-center space-x-2">\n'
+                f'          <Checkbox id="{fname}" checked={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: (e.target as HTMLInputElement).checked}}))}}/>\n'
+                f'          <Label htmlFor="{fname}">{flabel}</Label>\n'
+                f"        </div>"
+            )
+        if ft == "date":
+            return (
+                f'        <div className="space-y-2">\n'
+                f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                f'          <Input id="{fname}" type="date"\n'
+                f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                f"        </div>"
+            )
+        if ft == "datetime":
+            return (
+                f'        <div className="space-y-2">\n'
+                f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                f'          <Input id="{fname}" type="datetime-local"\n'
+                f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                f"        </div>"
+            )
+        if ft in ("integer", "long"):
+            return (
+                f'        <div className="space-y-2">\n'
+                f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                f'          <Input id="{fname}" type="number"\n'
+                f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                f"        </div>"
+            )
+        if ft == "decimal":
+            return (
+                f'        <div className="space-y-2">\n'
+                f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                f'          <Input id="{fname}" type="number" step="0.01"\n'
+                f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+                f"        </div>"
+            )
+        if ft == "enum" and field.get("values"):
+            options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in field["values"])
+            return (
+                f'        <div className="space-y-2">\n'
+                f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                f'          <select id="{fname}" className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"\n'
+                f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+                f'              <option value="">Select {flabel}...</option>{options}\n'
+                f"            </select>\n"
+                f"        </div>"
+            )
+        # string / fallback
+        return (
+            f'        <div className="space-y-2">\n'
+            f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+            f'          <Input id="{fname}" type="text"\n'
+            f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+            f"        </div>"
+        )
+
+    # Plain-HTML fallback
+    if ft == "text":
+        return (
+            f"        <div>\n"
+            f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+            f'          <textarea id="{fname}" className="mt-1 flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm" rows={{3}}\n'
+            f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+            f"        </div>"
+        )
+    if ft == "boolean":
+        return (
+            f'        <div className="flex items-center space-x-2">\n'
+            f'          <input id="{fname}" type="checkbox" className="h-4 w-4 rounded border-primary" checked={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.checked}}))}}/>\n'
+            f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}</label>\n'
+            f"        </div>"
+        )
+    if ft == "enum" and field.get("values"):
+        options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in field["values"])
+        return (
+            f"        <div>\n"
+            f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+            f'          <select id="{fname}" className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"\n'
+            f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}>\n"
+            f'              <option value="">Select {flabel}...</option>{options}\n'
+            f"            </select>\n"
+            f"        </div>"
+        )
+    input_type = (
+        "number"
+        if ft in ("integer", "long", "decimal")
+        else "date"
+        if ft == "date"
+        else "datetime-local"
+        if ft == "datetime"
+        else "text"
+    )
+    step = ' step="0.01"' if ft == "decimal" else ""
+    return (
+        f"        <div>\n"
+        f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+        f'          <input id="{fname}" type="{input_type}"{step} className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"\n'
+        f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
+        f"        </div>"
+    )
+
+
+def emit_settings(page: dict, ctx: PageContext) -> None:
+    """Generate a settings page — singleton record with grouped sections."""
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    grouped = _group_fields(fields)
+
+    # ui-kit imports — Accordion is a Phase 0 addition.
+    if ui:
+        ui_import = (
+            f"import {{ Button, Input, Label, Textarea, Checkbox, "
+            f"Card, CardContent, CardHeader, CardTitle, Alert, AlertDescription, "
+            f'Accordion, AccordionItem, AccordionTrigger, AccordionContent }} from "{ui}";\n'
+        )
+    else:
+        ui_import = ""
+
+    # Form state defaults (empty strings / false) — seeded by useEffect once
+    # the singleton fetch resolves.
+    defaults: dict[str, str] = {}
+    for f in fields:
+        fname = camel_case(f["name"])
+        defaults[fname] = "false" if f.get("type") == "boolean" else '""'
+    state_init = ", ".join(f"{k}: {v}" for k, v in defaults.items())
+
+    # Hydration — same rules as edit_type: stringify numbers, slice datetime.
+    hydrate_lines: list[str] = []
+    for f in fields:
+        ft = f.get("type", "string")
+        fname = camel_case(f["name"])
+        if ft == "boolean":
+            hydrate_lines.append(f"          {fname}: data.{fname} ?? false,")
+        elif ft in ("integer", "long", "decimal"):
+            hydrate_lines.append(f'          {fname}: data.{fname} != null ? String(data.{fname}) : "",')
+        elif ft == "datetime":
+            hydrate_lines.append(f'          {fname}: data.{fname} ? String(data.{fname}).slice(0, 16) : "",')
+        else:
+            hydrate_lines.append(f'          {fname}: data.{fname} ?? "",')
+    hydrate_str = "\n".join(hydrate_lines)
+
+    # Body of the PUT — cast numeric fields.
+    body_fields: list[str] = []
+    for f in fields:
+        ft = f.get("type", "string")
+        fname = camel_case(f["name"])
+        if ft in ("integer", "long", "decimal"):
+            body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
+        elif ft == "boolean":
+            body_fields.append(f"        {fname}: form.{fname},")
+        else:
+            body_fields.append(f"        {fname}: form.{fname} || undefined,")
+    body_str = "\n".join(body_fields)
+
+    # Build grouped content — Accordion in ui branch, plain sections in fallback.
+    if ui:
+        # All groups open by default so users don't have to click through.
+        default_values = "[" + ", ".join(f'"{g}"' for g, _ in grouped) + "]"
+        group_items = []
+        for group_label, group_fields in grouped:
+            inputs_jsx = "\n".join(_render_input(f, True) for f in group_fields)
+            group_items.append(
+                f'              <AccordionItem value="{group_label}">\n'
+                f"                <AccordionTrigger>{group_label}</AccordionTrigger>\n"
+                f"                <AccordionContent>\n"
+                f'                  <div className="space-y-4 pt-2">\n'
+                f"{inputs_jsx}\n"
+                f"                  </div>\n"
+                f"                </AccordionContent>\n"
+                f"              </AccordionItem>"
+            )
+        groups_block = (
+            f'            <Accordion type="multiple" defaultValue={{{default_values}}} className="w-full">\n'
+            + "\n".join(group_items)
+            + "\n            </Accordion>"
+        )
+        submit_btn = (
+            '            <div style={{ paddingTop: "1.5rem" }}>\n'
+            '              <Button type="submit" disabled={mutation.isPending}>\n'
+            '                {mutation.isPending ? t("saving") : t("save")}\n'
+            "              </Button>\n"
+            "            </div>"
+        )
+        success_msg = (
+            '            {success && <Alert className="mb-2">'
+            '<AlertDescription>{t("updatedSuccessfully")}</AlertDescription></Alert>}'
+        )
+        error_msg = (
+            "            {mutation.error && "
+            '<Alert variant="destructive" className="mb-2"><AlertDescription>'
+            "{(mutation.error as Error).message}</AlertDescription></Alert>}"
+        )
+        wrapper_open = (
+            f"      <Card>\n"
+            f"        <CardHeader>\n"
+            f"          <CardTitle>{label}</CardTitle>\n"
+            f"        </CardHeader>\n"
+            f"        <CardContent>\n"
+            f"{success_msg}\n"
+            f"{error_msg}\n"
+            f'          <form onSubmit={{handleSubmit}} className="space-y-4">'
+        )
+        wrapper_close = "          </form>\n        </CardContent>\n      </Card>"
+    else:
+        # No Accordion without --uikit; render groups as plain bordered sections
+        # so the visual hierarchy still reads.
+        group_items = []
+        for group_label, group_fields in grouped:
+            inputs_jsx = "\n".join(_render_input(f, False) for f in group_fields)
+            group_items.append(
+                f'            <section className="rounded-lg border p-4 space-y-4">\n'
+                f'              <h2 className="font-semibold">{group_label}</h2>\n'
+                f"{inputs_jsx}\n"
+                f"            </section>"
+            )
+        groups_block = "\n".join(group_items)
+        submit_btn = (
+            '            <div style={{ paddingTop: "1.5rem" }}>\n'
+            '              <button type="submit" disabled={mutation.isPending}\n'
+            '                className="inline-flex items-center justify-center rounded-md '
+            "text-sm font-medium bg-primary text-primary-foreground h-10 px-4 py-2 "
+            'hover:bg-primary/90 disabled:opacity-50">\n'
+            '                {mutation.isPending ? t("saving") : t("save")}\n'
+            "              </button>\n"
+            "            </div>"
+        )
+        success_msg = (
+            '            {success && <div className="mb-2 p-3 rounded-md border bg-green-50 text-green-800 text-sm">'
+            '{t("updatedSuccessfully")}</div>}'
+        )
+        error_msg = (
+            "            {mutation.error && "
+            '<div className="mb-2 p-3 rounded-md border border-destructive/50 '
+            'bg-destructive/5 text-destructive text-sm">'
+            "{(mutation.error as Error).message}</div>}"
+        )
+        wrapper_open = (
+            f'      <h1 className="text-2xl font-bold tracking-tight mb-4">{label}</h1>\n'
+            f"{success_msg}\n"
+            f"{error_msg}\n"
+            f'      <form onSubmit={{handleSubmit}} className="space-y-6">'
+        )
+        wrapper_close = "      </form>"
+
+    dest.write_text(
+        f'import {{ useState, useEffect }} from "react";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ useQuery, useMutation, useQueryClient }} from "@tanstack/react-query";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ Update{entity}Request, {entity} }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f"  const queryClient = useQueryClient();\n"
+        f"  const [form, setForm] = useState({{ {state_init} }});\n"
+        f"  const [success, setSuccess] = useState(false);\n"
+        f"\n"
+        f"  const {{ data, isLoading, error: fetchError }} = useQuery<{entity}>({{  \n"
+        f'    queryKey: ["{resource}"],\n'
+        f'    queryFn: () => api.get<{entity}>("/{resource}"),\n'
+        f"  }});\n"
+        f"\n"
+        f"  useEffect(() => {{\n"
+        f"    if (data) {{\n"
+        f"      setForm({{\n"
+        f"{hydrate_str}\n"
+        f"      }});\n"
+        f"    }}\n"
+        f"  }}, [data]);\n"
+        f"\n"
+        f"  const mutation = useMutation({{\n"
+        f"    mutationFn: (payload: Update{entity}Request) =>\n"
+        f'      api.put<{entity}>("/{resource}", payload),\n'
+        f"    onSuccess: () => {{\n"
+        f'      queryClient.invalidateQueries({{ queryKey: ["{resource}"] }});\n'
+        f"      setSuccess(true);\n"
+        f"      setTimeout(() => setSuccess(false), 3000);\n"
+        f"    }},\n"
+        f"  }});\n"
+        f"\n"
+        f"  const handleSubmit = (e: React.FormEvent) => {{\n"
+        f"    e.preventDefault();\n"
+        f"    mutation.mutate({{\n"
+        f"{body_str}\n"
+        f"    }} as Update{entity}Request);\n"
+        f"  }};\n"
+        f"\n"
+        f'  if (isLoading) return <p className="text-muted-foreground">{{t("loading")}}</p>;\n'
+        f"  if (fetchError)\n"
+        f'    return <p className="text-destructive">{{t("failedToLoad")}}: {{(fetchError as Error).message}}</p>;\n'
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f"{wrapper_open}\n"
+        f"{groups_block}\n"
+        f"{submit_btn}\n"
+        f"{wrapper_close}\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="settings",
+    description="Configuration form for a singleton resource — grouped fields in an Accordion, fetched via GET and saved via PUT.",
+    emit=emit_settings,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/tests/test_page_types_settings.py
+++ b/tests/test_page_types_settings.py
@@ -1,0 +1,194 @@
+"""Tests for the ``settings`` page type — grouped configuration form for a singleton."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_settings_type_is_registered() -> None:
+    info = get_registry().get("settings")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description
+
+
+# ── Emitter fixture ────────────────────────────────────────────────────────
+
+
+def _generate_org_settings(tmp_path: Path, *, uikit: str = "my-ui") -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "settings",
+        "label": "Organization Settings",
+        "resource": "orgSettings",
+        "type": "settings",
+        "fields": [
+            {"name": "companyName", "type": "string", "group": "Company", "required": True},
+            {"name": "billingEmail", "type": "string", "group": "Billing"},
+            {"name": "autoRenew", "type": "boolean", "group": "Billing"},
+            {"name": "maintenance", "type": "boolean"},  # ungrouped -> "General"
+            {"name": "supportHours", "type": "integer", "group": "Support"},
+            {"name": "notes", "type": "text", "group": "Support"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "SettingsPage.tsx").read_text()
+
+
+# ── Singleton fetch + PUT ──────────────────────────────────────────────────
+
+
+def test_settings_fetches_singleton_resource(tmp_path: Path) -> None:
+    """GET /{resource} without an id — that's what makes it a settings page."""
+    tsx = _generate_org_settings(tmp_path)
+    assert "useQuery<OrgSettings>" in tsx
+    assert 'api.get<OrgSettings>("/orgSettings")' in tsx
+    # No id plumbing at all
+    assert "URLSearchParams" not in tsx
+    assert "${id}" not in tsx
+
+
+def test_settings_saves_via_put_on_singleton(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path)
+    assert 'api.put<OrgSettings>("/orgSettings", payload)' in tsx
+    assert "UpdateOrgSettingsRequest" in tsx
+    # No DELETE — settings are persistent config, not CRUD records
+    assert "api.delete" not in tsx
+
+
+def test_settings_hydrates_form_on_fetch(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path)
+    assert "useEffect(() => {" in tsx
+    # Numbers stringified for Input[type=number]
+    assert 'supportHours: data.supportHours != null ? String(data.supportHours) : "",' in tsx
+    # Booleans default to false
+    assert "autoRenew: data.autoRenew ?? false," in tsx
+    # Strings default to ""
+    assert 'companyName: data.companyName ?? "",' in tsx
+
+
+def test_settings_invalidates_its_own_query_on_save(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path)
+    assert 'queryClient.invalidateQueries({ queryKey: ["orgSettings"] })' in tsx
+    assert 't("updatedSuccessfully")' in tsx
+
+
+# ── Grouping ───────────────────────────────────────────────────────────────
+
+
+def test_settings_renders_accordion_with_all_groups_expanded(tmp_path: Path) -> None:
+    """All groups open by default; users shouldn't have to click to see settings."""
+    tsx = _generate_org_settings(tmp_path, uikit="my-ui")
+    assert '<Accordion type="multiple"' in tsx
+    # defaultValue lists every group in declaration order
+    assert 'defaultValue={["Company", "Billing", "General", "Support"]}' in tsx
+
+
+def test_settings_groups_fields_by_group_key(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path, uikit="my-ui")
+    for g in ["Company", "Billing", "General", "Support"]:
+        assert f'value="{g}">' in tsx
+        assert f"<AccordionTrigger>{g}</AccordionTrigger>" in tsx
+
+
+def test_settings_ungrouped_fields_go_into_general_section(tmp_path: Path) -> None:
+    """Fields without a ``group`` key collect under "General" in declaration order."""
+    tsx = _generate_org_settings(tmp_path, uikit="my-ui")
+    # maintenance has no group, so it's inside the General accordion item.
+    # Find the "General" AccordionItem and confirm the maintenance input is in it.
+    general_start = tsx.index('value="General"')
+    general_end = tsx.index("</AccordionItem>", general_start)
+    general_body = tsx[general_start:general_end]
+    assert 'id="maintenance"' in general_body
+
+
+# ── Type-aware inputs ──────────────────────────────────────────────────────
+
+
+def test_settings_renders_expected_inputs(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path, uikit="my-ui")
+    assert '<Input id="companyName" type="text"' in tsx
+    assert '<Input id="supportHours" type="number"' in tsx
+    assert '<Checkbox id="autoRenew"' in tsx
+    assert '<Checkbox id="maintenance"' in tsx
+    assert '<Textarea id="notes"' in tsx
+
+
+def test_settings_required_field_shows_star(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path)
+    assert "Company Name *" in tsx
+
+
+# ── Plain-HTML fallback ────────────────────────────────────────────────────
+
+
+def test_settings_plain_fallback_uses_bordered_sections_no_accordion(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path, uikit="")
+    # No Accordion in the plain branch
+    assert "Accordion" not in tsx
+    # Groups render as <section> with a heading instead
+    assert '<section className="rounded-lg border p-4 space-y-4">' in tsx
+    assert '<h2 className="font-semibold">Company</h2>' in tsx
+    assert '<h2 className="font-semibold">Billing</h2>' in tsx
+    assert '<h2 className="font-semibold">General</h2>' in tsx
+    assert '<h2 className="font-semibold">Support</h2>' in tsx
+
+
+def test_settings_plain_fallback_has_no_shadcn_imports(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path, uikit="")
+    assert "Card" not in tsx
+    assert "Checkbox" not in tsx
+
+
+# ── Loading / error states ─────────────────────────────────────────────────
+
+
+def test_settings_shows_loading_and_fetch_error(tmp_path: Path) -> None:
+    tsx = _generate_org_settings(tmp_path)
+    assert 't("loading")' in tsx
+    assert 't("failedToLoad")' in tsx
+
+
+# ── Edge case: all fields ungrouped ────────────────────────────────────────
+
+
+def test_settings_with_no_group_keys_collects_everything_under_general(tmp_path: Path) -> None:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "settings",
+        "label": "Simple Settings",
+        "resource": "userPrefs",
+        "type": "settings",
+        "fields": [
+            {"name": "theme", "type": "string"},
+            {"name": "emailAlerts", "type": "boolean"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+    )
+    tsx = (project_root / "src" / "routes" / "SettingsPage.tsx").read_text()
+    # Exactly one AccordionItem — the "General" bucket
+    assert tsx.count("<AccordionItem") == 1
+    assert 'value="General"' in tsx


### PR DESCRIPTION
## Summary

Fourth Phase 2 page type — **`settings`**: a configuration form for a **singleton** resource. Unlike `form`/`edit` which operate on a collection, `settings` treats `/{resource}` as one record (no id), matching the shape of org settings, user preferences, billing config, feature flags, etc.

## Why it's a distinct type

Wrapping a singleton in the `list + detail + edit` pattern forces synthetic ids and pointless list pages. Real SaaS apps have a lot of these one-record config surfaces; `settings` is the idiomatic shape.

## Behaviour

| Step | What happens |
|---|---|
| Fetch | `useQuery` + `GET /{resource}` with queryKey `["<resource>"]` (no id) |
| Hydrate | `useEffect` seeds form state — numbers stringified, datetime trimmed, booleans default to `false` |
| Group | Fields bucket by optional `group` key; rendered as `Accordion type="multiple"` with every group **open by default** — settings should be visible at a glance, not hidden behind clicks |
| "General" | Fields without a `group` collect under "General" |
| Save | PUT the singleton, invalidate the query so the form rehydrates. `t("updatedSuccessfully")` feedback. |
| No delete | Settings are persistent config — the `AlertDialog` destructive flow from `edit` is intentionally absent |

Plain-HTML fallback: each group becomes a bordered `<section>` with an `<h2>` heading (no Accordion), so the visual hierarchy still reads.

Input rendering covers the same types as `form` / `edit` (string, text, integer, long, decimal, boolean, date, datetime, enum). Resource-lookup auto-detection is intentionally skipped — a singleton has no cross-resource relations in this pattern.

## Example page config

```json
{
  "path": "settings",
  "label": "Organization Settings",
  "resource": "orgSettings",
  "type": "settings",
  "fields": [
    {"name": "companyName",  "type": "string",  "group": "Company", "required": true},
    {"name": "billingEmail", "type": "string",  "group": "Billing"},
    {"name": "autoRenew",    "type": "boolean", "group": "Billing"},
    {"name": "maintenance",  "type": "boolean"},
    {"name": "supportHours", "type": "integer", "group": "Support"},
    {"name": "notes",        "type": "text",    "group": "Support"}
  ]
}
```

Emits an Accordion with four items — Company, Billing, General (just `maintenance`), Support — all expanded by default.

## Test plan

- [x] 14 new tests in `tests/test_page_types_settings.py`:
  - Registration + metadata
  - Singleton fetch (GET without id, no `URLSearchParams`, no `${id}`)
  - PUT save + `UpdateOrgSettingsRequest` type
  - No DELETE
  - Hydration: number stringification, boolean default, string default
  - Accordion `type="multiple"` with every group in `defaultValue`
  - Groups bucket in declaration order
  - Ungrouped fields inside the "General" AccordionItem
  - Type-aware inputs (string, number, boolean, textarea)
  - Required-field star
  - Plain-HTML fallback uses `<section>` + `<h2>` and has **no** Accordion/Card/Checkbox imports
  - Loading / fetch-error states
  - Edge case: all-ungrouped fields → one "General" AccordionItem
- [x] **Full suite: 171/171 passing** (157 pre-existing + 14 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated a ui-kit + api-client + frontend-app with a settings page; `vite build` succeeds.

## Docs

- `CLAUDE.md` — new `settings` entry under **Page types**; `pages/` tree extended

## Phase 2 progress

4/7 new page types landed: ~~`detail`~~ ✅ · ~~`grid`~~ ✅ · ~~`edit`~~ ✅ · ~~`settings`~~ ✅ · `tree` · `kanban` · `calendar`

The remaining three all adopt third-party libs (`react-arborist`, `@dnd-kit`, `@schedule-x/react` respectively) — a notable step up in scope from the first four.
