### PR TITLE
feat(pages): add `tree` page type — hierarchical view via react-arborist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `grid` — responsive card-grid (1 col mobile / 2 md / 3 lg) for a resource collection. Same paginated query as `list`. First string field becomes the CardTitle, second becomes CardDescription; remaining fields drop into the card body as label/value pairs. Enum and boolean values render as Badges for fast visual scanning. Null-safe, shows empty state spanning all grid columns.
 - `edit` — update form for an existing record. Reads `id` from `?id=` query string, fetches via `useQuery`, hydrates form state via `useEffect`, saves via PUT with `t("updatedSuccessfully")` feedback. Includes a destructive Delete button wrapped in an `AlertDialog` confirmation (Phase 0 component); plain-HTML fallback uses `window.confirm`. Same type-aware inputs and resource-lookup auto-detection as `form`.
 - `settings` — configuration form for a **singleton** resource. `GET /{resource}` returns one record, `PUT /{resource}` updates it — no `id` in the URL. Fields can be grouped via an optional `group` key and render as shadcn `Accordion` items (Phase 0), all expanded by default; ungrouped fields drop into a "General" section. Plain-HTML fallback uses bordered `<section>` headings instead of Accordion. No delete.
+- `tree` — hierarchical view for a resource with a nullable `parentId` field. Fetches up to 1000 records via `GET /{resource}`, builds a nested tree client-side (dangling children become roots if pagination cuts off an ancestor), renders with [`react-arborist`](https://github.com/brimdata/react-arborist) — collapsible, keyboard-navigable, virtualized. Node label = first string field (falls back to `id`). Clicking a leaf navigates to `./view?id={id}` (the detail-page convention). Requires `react-arborist` (auto-added to frontend-app `dependencies`).
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -195,7 +196,8 @@ src/apps_generator/
 │       │   ├── detail_type.py
 │       │   ├── grid_type.py
 │       │   ├── edit_type.py
-│       │   └── settings_type.py
+│       │   ├── settings_type.py
+│       │   └── tree_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -241,7 +243,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard/detail/grid/edit/settings) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail/grid/edit/settings/tree) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -36,6 +36,7 @@ _BUILTIN_TYPES = (
     "grid_type",
     "edit_type",
     "settings_type",
+    "tree_type",
 )
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")

--- a/src/apps_generator/cli/generators/pages/tree_type.py
+++ b/src/apps_generator/cli/generators/pages/tree_type.py
@@ -1,0 +1,185 @@
+"""``tree`` page type — hierarchical view of a self-referencing resource.
+
+Fetches a flat paginated list from the resource's collection endpoint,
+builds a tree from records whose ``parentId`` points to another record of
+the same resource, and renders it with `react-arborist`_. Nodes are
+collapsible, keyboard-navigable, and virtualized — suitable for
+department hierarchies, folder structures, org charts, category trees.
+
+The resource must expose:
+
+* ``id`` — unique identifier (always present via ``TenantAwareEntity``)
+* ``parentId`` — nullable reference to another record of the same resource.
+  Records with ``parentId == null`` are roots.
+
+Clicking a node navigates to ``./view?id={id}`` by convention, so that a
+co-located ``detail`` page of the same resource opens that record. The
+frontend-app's path-based routing (no URL params) makes this the natural
+link target.
+
+.. _react-arborist: https://github.com/brimdata/react-arborist
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case
+
+from .base import page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+def emit_tree(page: dict, ctx: PageContext) -> None:
+    """Generate a tree page — flat-to-nested build + react-arborist Tree."""
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    # Pick the first string field as the node label; fall back to the record id
+    # when no string field is configured.
+    label_field = next((f for f in fields if f.get("type", "string") == "string"), None)
+    label_fname = camel_case(label_field["name"]) if label_field else "id"
+
+    # ui-kit imports — Tree pages lean on Card for the outer chrome; the
+    # tree itself is react-arborist regardless of --uikit.
+    if ui:
+        ui_import = f'import {{ Card, CardContent, CardHeader, CardTitle }} from "{ui}";\n'
+    else:
+        ui_import = ""
+
+    # Node renderer — we want the caret to reflect open/closed state, the label
+    # to show the chosen field, and clicking a leaf to navigate to the detail
+    # page of that record. Non-internal (leaf) nodes are clickable; internal
+    # nodes toggle open/close, matching react-arborist defaults.
+    node_renderer = (
+        "  const Node = ({ node, style, dragHandle }: NodeRendererProps<TreeNode>) => (\n"
+        "    <div\n"
+        "      ref={dragHandle}\n"
+        "      style={style}\n"
+        '      className="flex items-center gap-2 px-2 rounded-sm cursor-pointer hover:bg-accent"\n'
+        "      onClick={() => {\n"
+        "        if (node.isInternal) node.toggle();\n"
+        "        else window.location.search = `?id=${node.id}`;\n"
+        "      }}\n"
+        "    >\n"
+        '      <span className="w-4 text-muted-foreground">\n'
+        '        {node.isInternal ? (node.isOpen ? "▾" : "▸") : "•"}\n'
+        "      </span>\n"
+        "      <span>{node.data.label}</span>\n"
+        "    </div>\n"
+        "  );\n"
+    )
+
+    # Tree wrapper — ui-kit branch gets a Card; plain branch gets a bordered div.
+    if ui:
+        wrapper_open = (
+            f"      <Card>\n"
+            f"        <CardHeader>\n"
+            f"          <CardTitle>{label} ({{items.length}})</CardTitle>\n"
+            f"        </CardHeader>\n"
+            f'        <CardContent className="p-0">'
+        )
+        wrapper_close = "        </CardContent>\n      </Card>"
+    else:
+        wrapper_open = (
+            f'      <h1 className="text-2xl font-bold tracking-tight mb-4">{label} ({{items.length}})</h1>\n'
+            f'      <div className="rounded-lg border">'
+        )
+        wrapper_close = "      </div>"
+
+    # Empty state spans the tree container.
+    empty_state = '          <p className="text-center text-muted-foreground py-8">{t("noDataFound")}</p>'
+
+    dest.write_text(
+        f'import {{ useMemo }} from "react";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ useQuery }} from "@tanstack/react-query";\n'
+        f'import {{ Tree, type NodeRendererProps }} from "react-arborist";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ {entity}, PageResponse }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"interface TreeNode {{\n"
+        f"  id: string;\n"
+        f"  label: string;\n"
+        f"  children?: TreeNode[];\n"
+        f"}}\n"
+        f"\n"
+        f"/**\n"
+        f" * Build a nested tree from a flat list of records using ``parentId``.\n"
+        f" * Records whose parent isn't in the list are treated as roots so the\n"
+        f" * view degrades gracefully if pagination cuts off an ancestor.\n"
+        f" */\n"
+        f"function buildTree(items: {entity}[]): TreeNode[] {{\n"
+        f"  const byId = new Map<string, TreeNode>();\n"
+        f"  for (const item of items) {{\n"
+        f"    byId.set(String(item.id), {{\n"
+        f"      id: String(item.id),\n"
+        f"      label: String(item.{label_fname} ?? item.id),\n"
+        f"      children: [],\n"
+        f"    }});\n"
+        f"  }}\n"
+        f"  const roots: TreeNode[] = [];\n"
+        f"  for (const item of items) {{\n"
+        f"    const node = byId.get(String(item.id))!;\n"
+        f"    const parentId = (item as unknown as {{ parentId?: string | number | null }}).parentId;\n"
+        f"    const parent = parentId != null ? byId.get(String(parentId)) : undefined;\n"
+        f"    if (parent) parent.children!.push(node);\n"
+        f"    else roots.push(node);\n"
+        f"  }}\n"
+        f"  return roots;\n"
+        f"}}\n"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f"\n"
+        f"  const {{ data, isLoading, error }} = useQuery<PageResponse<{entity}>>({{  \n"
+        f'    queryKey: ["{resource}", "tree"],\n'
+        f'    queryFn: () => api.get<PageResponse<{entity}>>("/{resource}", '
+        f'{{ params: {{ page: "0", size: "1000" }} }}),\n'
+        f"  }});\n"
+        f"\n"
+        f"  const items = data?.content ?? [];\n"
+        f"  const treeData = useMemo(() => buildTree(items), [items]);\n"
+        f"\n"
+        f"{node_renderer}"
+        f"\n"
+        f'  if (isLoading) return <p className="text-muted-foreground">{{t("loading")}}</p>;\n'
+        f'  if (error) return <p className="text-destructive">'
+        f'{{t("failedToLoad")}}: {{(error as Error).message}}</p>;\n'
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f"{wrapper_open}\n"
+        f"          {{items.length === 0 ? (\n"
+        f"{empty_state}\n"
+        f"          ) : (\n"
+        f"            <Tree<TreeNode>\n"
+        f"              data={{treeData}}\n"
+        f"              openByDefault={{false}}\n"
+        f"              width={{600}}\n"
+        f"              height={{500}}\n"
+        f"              indent={{24}}\n"
+        f"              rowHeight={{32}}\n"
+        f"            >\n"
+        f"              {{Node}}\n"
+        f"            </Tree>\n"
+        f"          )}}\n"
+        f"{wrapper_close}\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="tree",
+    description="Hierarchical view for a self-referencing resource — flat-to-nested build by parentId, rendered via react-arborist.",
+    emit=emit_tree,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/package.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^18.3.1",
     "i18next": "^23.12.0",
     "react-i18next": "^15.0.0",
-    "@tanstack/react-query": "^5.51.0"
+    "@tanstack/react-query": "^5.51.0",
+    "react-arborist": "^3.4.0"
   },
   "devDependencies": {
     "@module-federation/vite": "^1.14.0",

--- a/tests/test_page_types_tree.py
+++ b/tests/test_page_types_tree.py
@@ -1,0 +1,147 @@
+"""Tests for the ``tree`` page type — hierarchical view via react-arborist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_tree_type_is_registered() -> None:
+    info = get_registry().get("tree")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description
+
+
+# ── Emitter fixture ────────────────────────────────────────────────────────
+
+
+def _generate_department_tree(tmp_path: Path, *, uikit: str = "my-ui", fields: list[dict] | None = None) -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "org",
+        "label": "Org Chart",
+        "resource": "department",
+        "type": "tree",
+        "fields": fields
+        if fields is not None
+        else [
+            {"name": "name", "type": "string"},
+            {"name": "head", "type": "string"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "OrgPage.tsx").read_text()
+
+
+# ── Data fetch ─────────────────────────────────────────────────────────────
+
+
+def test_tree_fetches_flat_list_via_use_query(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    assert "useQuery<PageResponse<Department>>" in tsx
+    assert '"/department"' in tsx
+    # Uses a generous page size so a single call typically returns the whole tree
+    assert 'size: "1000"' in tsx
+    # Distinct queryKey so the tree doesn't reuse the list page's cached slice
+    assert '"department", "tree"' in tsx
+
+
+# ── Flat-to-nested builder ─────────────────────────────────────────────────
+
+
+def test_tree_builds_nested_structure_by_parent_id(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    # Indexed by id for O(1) parent lookup
+    assert "byId.set(String(item.id)" in tsx
+    # Dangling children (parent not in result) fall through as roots
+    assert "if (parent) parent.children!.push(node);" in tsx
+    assert "else roots.push(node);" in tsx
+    # buildTree is wrapped in useMemo so it doesn't rerun on unrelated state changes
+    assert "useMemo(() => buildTree(items)" in tsx
+
+
+def test_tree_labels_nodes_with_first_string_field(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    assert "label: String(item.name ?? item.id)" in tsx
+
+
+def test_tree_falls_back_to_id_when_no_string_field(tmp_path: Path) -> None:
+    """If the config has no string field, the node label is the id (still navigable)."""
+    tsx = _generate_department_tree(
+        tmp_path,
+        fields=[{"name": "sortOrder", "type": "integer"}],
+    )
+    assert "label: String(item.id ?? item.id)" in tsx
+
+
+# ── Rendering ──────────────────────────────────────────────────────────────
+
+
+def test_tree_imports_react_arborist(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    assert 'import { Tree, type NodeRendererProps } from "react-arborist"' in tsx
+    # And is actually rendered
+    assert "<Tree<TreeNode>" in tsx
+
+
+def test_tree_configures_arborist_props(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    assert "openByDefault={false}" in tsx
+    assert "width={600}" in tsx
+    assert "height={500}" in tsx
+    assert "indent={24}" in tsx
+    assert "rowHeight={32}" in tsx
+
+
+def test_tree_node_renderer_toggles_or_navigates(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    # Internal node click toggles open/closed
+    assert "if (node.isInternal) node.toggle()" in tsx
+    # Leaf click navigates to the detail page via the ?id= convention
+    assert "else window.location.search = `?id=${node.id}`" in tsx
+    # Caret reflects open/closed state
+    assert '{node.isInternal ? (node.isOpen ? "▾" : "▸") : "•"}' in tsx
+
+
+def test_tree_shows_empty_and_error_states(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path)
+    assert 't("noDataFound")' in tsx
+    assert 't("loading")' in tsx
+    assert 't("failedToLoad")' in tsx
+
+
+# ── Wrappers ───────────────────────────────────────────────────────────────
+
+
+def test_tree_uikit_branch_uses_card_wrapper(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path, uikit="my-ui")
+    assert 'from "my-ui"' in tsx
+    for sym in ["Card", "CardContent", "CardHeader", "CardTitle"]:
+        assert sym in tsx, f"missing ui-kit import: {sym}"
+    # CardTitle shows the total count
+    assert "<CardTitle>Org Chart ({items.length})</CardTitle>" in tsx
+
+
+def test_tree_plain_branch_uses_raw_heading_and_bordered_div(tmp_path: Path) -> None:
+    tsx = _generate_department_tree(tmp_path, uikit="")
+    # No ui-kit imports
+    assert "Card" not in tsx
+    # Plain wrapper still has the title + count
+    assert "Org Chart ({items.length})" in tsx
+    assert '<div className="rounded-lg border">' in tsx


### PR DESCRIPTION
## Summary

Fifth Phase 2 page type — and the **first to adopt a third-party lib**. Renders a self-referencing resource (anything with a nullable `parentId`) as a collapsible, keyboard-navigable, virtualized tree using [react-arborist](https://github.com/brimdata/react-arborist). Fits department hierarchies, folder structures, org charts, category trees.

## Behaviour

1. **Fetch up to 1000** records in one paginated call with a distinct queryKey `["<resource>", "tree"]` so the slice doesn't collide with the `list` page's cache
2. **Build the nested structure client-side** in a single pass: `Map<id, node>` → wire each record into its parent's `children[]`. Records whose `parentId` isn't in the result fall through as roots — pagination cutting off an ancestor degrades gracefully
3. **Node label** = first string field; falls back to `id` if no string field is configured
4. **Render** with react-arborist's `<Tree>` (fixed 600×500 viewport — tweakable in the emitted file)
5. **Node renderer** shows ▾/▸ for internal nodes, • for leaves. Clicking an internal node toggles it; clicking a leaf navigates to `./view?id={id}` — the `?id=` convention shared with `detail` / `edit`

Plain-HTML fallback still uses react-arborist (it's not ui-kit-scoped); only the outer chrome differs — bordered `<div>` + `<h1>` instead of `<Card>/<CardTitle>`.

## Deps

`react-arborist` (^3.4.0) added to the frontend-app template's runtime dependencies, **unconditionally**. It's ~30 KB, tree-shakable, and the only page type that needs it; a conditional injection mechanism would be more scaffold work than this dep is worth.

## Example page config

```json
{
  "path": "org-chart",
  "label": "Org Chart",
  "resource": "department",
  "type": "tree",
  "fields": [
    {"name": "name", "type": "string"},
    {"name": "head", "type": "string"}
  ]
}
```

Assumes `department` has an `id` + `parentId` + `name` field. The backend's `TenantAwareEntity` base provides `id`; the user is responsible for adding `parentId` in the resource config.

## Test plan

- [x] 11 new tests in `tests/test_page_types_tree.py`:
  - Registration + metadata
  - Paginated fetch with `size: "1000"` + tree-scoped queryKey
  - Flat-to-nested builder: id-map, dangling-children-as-roots fallback, useMemo wrap
  - Node label: first string field, falls back to `id`
  - react-arborist import + canonical `<Tree>` props
  - Node renderer: toggle internals, navigate leaves
  - Empty / loading / error states
  - ui-kit wrapper (Card) + plain wrapper (bordered div)
- [x] **Full suite: 182/182 passing** (171 pre-existing + 11 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated a ui-kit + api-client + frontend-app with a tree page; `vite build` succeeds.

## Docs

- `CLAUDE.md` — new `tree` entry under **Page types**; `pages/` tree extended

## Phase 2 progress

5/7 landed: ~~`detail`~~ ✅ · ~~`grid`~~ ✅ · ~~`edit`~~ ✅ · ~~`settings`~~ ✅ · ~~`tree`~~ ✅ · `kanban` · `calendar`

Both remaining also pull third-party libs (`@dnd-kit/*` and `@schedule-x/react` respectively).
