### PR TITLE
feat(pages): add `kanban` page type — drag-and-drop board by status enum

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `edit` — update form for an existing record. Reads `id` from `?id=` query string, fetches via `useQuery`, hydrates form state via `useEffect`, saves via PUT with `t("updatedSuccessfully")` feedback. Includes a destructive Delete button wrapped in an `AlertDialog` confirmation (Phase 0 component); plain-HTML fallback uses `window.confirm`. Same type-aware inputs and resource-lookup auto-detection as `form`.
 - `settings` — configuration form for a **singleton** resource. `GET /{resource}` returns one record, `PUT /{resource}` updates it — no `id` in the URL. Fields can be grouped via an optional `group` key and render as shadcn `Accordion` items (Phase 0), all expanded by default; ungrouped fields drop into a "General" section. Plain-HTML fallback uses bordered `<section>` headings instead of Accordion. No delete.
 - `tree` — hierarchical view for a resource with a nullable `parentId` field. Fetches up to 1000 records via `GET /{resource}`, builds a nested tree client-side (dangling children become roots if pagination cuts off an ancestor), renders with [`react-arborist`](https://github.com/brimdata/react-arborist) — collapsible, keyboard-navigable, virtualized. Node label = first string field (falls back to `id`). Clicking a leaf navigates to `./view?id={id}` (the detail-page convention). Requires `react-arborist` (auto-added to frontend-app `dependencies`).
+- `kanban` — drag-and-drop board grouped by a status enum. Columns are the enum's `values`; dropping a card PATCHes the record's status field with the new column value, with an optimistic local update so the UI never lags. Column resolution: explicit `statusField` > field named `status`/`state`/`stage`/`phase` > first enum field > single "Backlog" fallback. Uses [`@dnd-kit/core`](https://dndkit.com/) + `@dnd-kit/sortable` + `@dnd-kit/utilities` — one `SortableContext` per column, 4 px pointer-activation distance.
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -197,7 +198,8 @@ src/apps_generator/
 │       │   ├── grid_type.py
 │       │   ├── edit_type.py
 │       │   ├── settings_type.py
-│       │   └── tree_type.py
+│       │   ├── tree_type.py
+│       │   └── kanban_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -243,7 +245,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard/detail/grid/edit/settings/tree) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail/grid/edit/settings/tree/kanban) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -37,6 +37,7 @@ _BUILTIN_TYPES = (
     "edit_type",
     "settings_type",
     "tree_type",
+    "kanban_type",
 )
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")

--- a/src/apps_generator/cli/generators/pages/kanban_type.py
+++ b/src/apps_generator/cli/generators/pages/kanban_type.py
@@ -1,0 +1,304 @@
+"""``kanban`` page type — drag-and-drop board grouped by a status enum.
+
+Renders records in columns keyed by an enum field's values. Cards are
+draggable between columns via `@dnd-kit/core`_ and `@dnd-kit/sortable`_;
+dropping a card into a different column PATCHes the underlying record
+with the new status value and optimistically moves the card so the UI
+never feels sluggish while the mutation is in flight.
+
+Picking the status field:
+
+1. If the page config sets ``statusField`` explicitly, use that.
+2. Otherwise, use the first ``enum`` field with a ``values`` array.
+3. If neither is available, the emitter still generates a page but the
+   board has a single "Backlog" column containing every record — a
+   graceful fallback rather than a hard error.
+
+.. _@dnd-kit/core: https://dndkit.com/
+.. _@dnd-kit/sortable: https://github.com/clauderic/dnd-kit
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case, title_case
+
+from .base import page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+_STATUS_NAME_HINTS = ("status", "state", "stage", "phase")
+
+
+def _pick_status_field(page: dict, fields: list[dict]) -> dict | None:
+    """Return the field whose enum values define the board's columns.
+
+    Resolution order:
+
+    1. Explicit ``statusField`` in the page config wins.
+    2. Otherwise prefer an enum field whose name matches a status-y hint
+       (``status`` / ``state`` / ``stage`` / ``phase``) — that's the convention
+       behind nearly every kanban board.
+    3. Fall back to the first enum field with a ``values`` array.
+    """
+    explicit = page.get("statusField")
+    if explicit:
+        for f in fields:
+            if f.get("name") == explicit:
+                return f
+    enum_fields = [f for f in fields if f.get("type") == "enum" and f.get("values")]
+    for f in enum_fields:
+        if f["name"].lower() in _STATUS_NAME_HINTS:
+            return f
+    return enum_fields[0] if enum_fields else None
+
+
+def _pick_title_field(fields: list[dict], exclude: dict | None) -> dict | None:
+    """First string field, skipping the one chosen as the status field."""
+    for f in fields:
+        if f is exclude:
+            continue
+        if f.get("type", "string") == "string":
+            return f
+    return None
+
+
+def emit_kanban(page: dict, ctx: PageContext) -> None:
+    """Generate a kanban page — DndContext + SortableContext per status column."""
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    status_field = _pick_status_field(page, fields)
+    title_field = _pick_title_field(fields, status_field)
+
+    # Column source-of-truth: the enum's values, or a single "Backlog" fallback.
+    if status_field and status_field.get("values"):
+        status_fname = camel_case(status_field["name"])
+        column_keys = status_field["values"]
+    else:
+        status_fname = ""
+        column_keys = ["Backlog"]
+    columns_ts = "[" + ", ".join(f'"{v}"' for v in column_keys) + "]"
+
+    title_fname = camel_case(title_field["name"]) if title_field else "id"
+
+    # Descriptor fields shown under the card title — all fields except title +
+    # status, rendered compactly. Keeps cards scannable.
+    used_names: set[str] = set()
+    if title_field:
+        used_names.add(title_field["name"])
+    if status_field:
+        used_names.add(status_field["name"])
+    body_fields = [f for f in fields if f["name"] not in used_names]
+
+    body_rows: list[str] = []
+    for f in body_fields:
+        flabel = title_case(f["name"])
+        fname = camel_case(f["name"])
+        ft = f.get("type", "string")
+        if ft == "decimal":
+            expr = f'item.{fname} != null ? `$${{item.{fname}.toFixed(2)}}` : "—"'
+        elif ft in ("date", "datetime"):
+            expr = f'item.{fname} ? new Date(item.{fname}).toLocaleDateString() : "—"'
+        elif ft == "boolean":
+            expr = f'item.{fname} == null ? "—" : item.{fname} ? t("yes") : t("no")'
+        else:
+            expr = f'item.{fname} ?? "—"'
+        body_rows.append(
+            f'          <div className="flex items-center justify-between gap-2 text-xs">\n'
+            f'            <span className="text-muted-foreground">{flabel}</span>\n'
+            f"            <span>{{{expr}}}</span>\n"
+            f"          </div>"
+        )
+    body_rows_str = "\n".join(body_rows)
+
+    # ui-kit imports — kanban leans on Card + Badge for column headers and cards.
+    if ui:
+        ui_import = f'import {{ Card, CardContent, CardHeader, CardTitle, Badge }} from "{ui}";\n'
+    else:
+        ui_import = ""
+
+    # Column header — with ui-kit it's a CardHeader + count badge; plain
+    # fallback uses a styled <h3>. Either way, the column label is the enum
+    # value title-cased.
+    if ui:
+        column_header = (
+            '          <div className="flex items-center justify-between mb-3">\n'
+            '            <h3 className="font-semibold text-sm">{statusLabel(status)}</h3>\n'
+            '            <Badge variant="secondary">{items.length}</Badge>\n'
+            "          </div>"
+        )
+        card_wrapper_open = "<Card>"
+        card_wrapper_close = "</Card>"
+    else:
+        column_header = (
+            '          <div className="flex items-center justify-between mb-3">\n'
+            '            <h3 className="font-semibold text-sm">{statusLabel(status)}</h3>\n'
+            '            <span className="text-xs text-muted-foreground rounded-full bg-muted px-2 py-0.5">{items.length}</span>\n'
+            "          </div>"
+        )
+        card_wrapper_open = '<div className="rounded-lg border bg-card p-4">'
+        card_wrapper_close = "</div>"
+
+    dest.write_text(
+        f'import {{ useMemo, useState, useEffect }} from "react";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ useQuery, useMutation, useQueryClient }} from "@tanstack/react-query";\n'
+        f"import {{\n"
+        f"  DndContext,\n"
+        f"  type DragEndEvent,\n"
+        f"  PointerSensor,\n"
+        f"  useSensor,\n"
+        f"  useSensors,\n"
+        f'}} from "@dnd-kit/core";\n'
+        f"import {{\n"
+        f"  SortableContext,\n"
+        f"  verticalListSortingStrategy,\n"
+        f"  useSortable,\n"
+        f'}} from "@dnd-kit/sortable";\n'
+        f'import {{ CSS }} from "@dnd-kit/utilities";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ {entity}, PageResponse, Update{entity}Request }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"const STATUSES = {columns_ts} as const;\n"
+        f"type Status = (typeof STATUSES)[number];\n"
+        f"\n"
+        f"/** Turn an enum value into a human-readable column header. */\n"
+        f"function statusLabel(s: Status): string {{\n"
+        f"  return String(s)\n"
+        f'    .replace(/([A-Z])/g, " $1")\n'
+        f"    .replace(/^./, (c) => c.toUpperCase())\n"
+        f"    .trim();\n"
+        f"}}\n"
+        f"\n"
+        f"interface CardProps {{ item: {entity}; t: (key: string) => string; }}\n"
+        f"\n"
+        f"/** Sortable card — what the user actually drags. */\n"
+        f"function DraggableCard({{ item, t }}: CardProps) {{\n"
+        f"  const {{ attributes, listeners, setNodeRef, transform, transition, isDragging }} =\n"
+        f"    useSortable({{ id: String(item.id) }});\n"
+        f"  const style = {{\n"
+        f"    transform: CSS.Transform.toString(transform),\n"
+        f"    transition,\n"
+        f"    opacity: isDragging ? 0.5 : 1,\n"
+        f"  }};\n"
+        f"  return (\n"
+        f"    <div ref={{setNodeRef}} style={{style}} {{...attributes}} {{...listeners}}>\n"
+        f"      {card_wrapper_open}\n"
+        f'        <div className="p-3 space-y-2 cursor-grab active:cursor-grabbing">\n'
+        f'          <div className="font-medium text-sm">{{String(item.{title_fname} ?? item.id)}}</div>\n'
+        + (f"{body_rows_str}\n" if body_rows_str else "")
+        + f"        </div>\n"
+        f"      {card_wrapper_close}\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f"  const queryClient = useQueryClient();\n"
+        f"\n"
+        f"  const {{ data, isLoading, error }} = useQuery<PageResponse<{entity}>>({{  \n"
+        f'    queryKey: ["{resource}", "kanban"],\n'
+        f'    queryFn: () => api.get<PageResponse<{entity}>>("/{resource}", '
+        f'{{ params: {{ page: "0", size: "1000" }} }}),\n'
+        f"  }});\n"
+        f"\n"
+        f"  // Local mirror of the server list so we can move cards optimistically\n"
+        f"  // and roll back on failure. Kept in sync with fetches via useEffect.\n"
+        f"  const [local, setLocal] = useState<{entity}[]>([]);\n"
+        f"  useEffect(() => {{\n"
+        f"    if (data) setLocal(data.content ?? []);\n"
+        f"  }}, [data]);\n"
+        f"\n"
+        f"  const grouped = useMemo(() => {{\n"
+        f"    const by: Record<string, {entity}[]> = {{}};\n"
+        f"    for (const s of STATUSES) by[s] = [];\n"
+        f"    for (const item of local) {{\n"
+        + (
+            f"      const s = String((item as any).{status_fname} ?? STATUSES[0]) as Status;\n"
+            if status_fname
+            else "      const s = STATUSES[0];\n"
+        )
+        + "      (by[s] ?? (by[STATUSES[0]])).push(item);\n"
+        "    }\n"
+        "    return by;\n"
+        "  }, [local]);\n"
+        "\n"
+        "  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));\n"
+        "\n"
+        "  const mutation = useMutation({\n"
+        "    mutationFn: ({ id, status }: { id: string; status: Status }) =>\n"
+        + (
+            f"      api.patch<{entity}>(`/{resource}/${{id}}`, {{ {status_fname}: status }} as Update{entity}Request),\n"
+            if status_fname
+            else f"      api.patch<{entity}>(`/{resource}/${{id}}`, {{}} as Update{entity}Request),\n"
+        )
+        + f'    onSettled: () => queryClient.invalidateQueries({{ queryKey: ["{resource}"] }}),\n'
+        f"  }});\n"
+        f"\n"
+        f"  const handleDragEnd = (e: DragEndEvent) => {{\n"
+        f"    const {{ active, over }} = e;\n"
+        f"    if (!over) return;\n"
+        f"    const target = String(over.id) as Status;\n"
+        f"    if (!STATUSES.includes(target)) return;\n"
+        f"    const id = String(active.id);\n"
+        f"    setLocal((prev) =>\n"
+        + (
+            f"      prev.map((it) => (String(it.id) === id ? {{ ...it, {status_fname}: target }} : it))\n"
+            if status_fname
+            else "      prev.map((it) => (String(it.id) === id ? it : it))\n"
+        )
+        + f"    );\n"
+        f"    mutation.mutate({{ id, status: target }});\n"
+        f"  }};\n"
+        f"\n"
+        f'  if (isLoading) return <p className="text-muted-foreground">{{t("loading")}}</p>;\n'
+        f'  if (error) return <p className="text-destructive">'
+        f'{{t("failedToLoad")}}: {{(error as Error).message}}</p>;\n'
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f'      <h1 className="text-2xl font-bold tracking-tight">{label}</h1>\n'
+        f"      <DndContext sensors={{sensors}} onDragEnd={{handleDragEnd}}>\n"
+        f'        <div className="grid gap-4" style={{{{ gridTemplateColumns: `repeat(${{STATUSES.length}}, minmax(240px, 1fr))` }}}}>\n'
+        f"          {{STATUSES.map((status) => {{\n"
+        f"            const items = grouped[status] ?? [];\n"
+        f"            return (\n"
+        f'              <div key={{status}} id={{status}} data-status={{status}} className="rounded-lg bg-muted/40 p-3">\n'
+        f"{column_header}\n"
+        f"                <SortableContext\n"
+        f"                  id={{status}}\n"
+        f"                  items={{items.map((i) => String(i.id))}}\n"
+        f"                  strategy={{verticalListSortingStrategy}}\n"
+        f"                >\n"
+        f'                  <div className="space-y-2 min-h-[4rem]">\n'
+        f"                    {{items.map((item) => (\n"
+        f"                      <DraggableCard key={{String(item.id)}} item={{item}} t={{t}} />\n"
+        f"                    ))}}\n"
+        f"                  </div>\n"
+        f"                </SortableContext>\n"
+        f"              </div>\n"
+        f"            );\n"
+        f"          }})}}\n"
+        f"        </div>\n"
+        f"      </DndContext>\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="kanban",
+    description="Drag-and-drop board grouped by a status enum — columns = enum values, drop PATCHes the record's status field.",
+    emit=emit_kanban,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/package.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/package.json
@@ -23,7 +23,10 @@
     "i18next": "^23.12.0",
     "react-i18next": "^15.0.0",
     "@tanstack/react-query": "^5.51.0",
-    "react-arborist": "^3.4.0"
+    "react-arborist": "^3.4.0",
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2"
   },
   "devDependencies": {
     "@module-federation/vite": "^1.14.0",

--- a/tests/test_page_types_kanban.py
+++ b/tests/test_page_types_kanban.py
@@ -1,0 +1,215 @@
+"""Tests for the ``kanban`` page type — drag-and-drop board grouped by status."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_kanban_type_is_registered() -> None:
+    info = get_registry().get("kanban")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description
+
+
+# ── Emitter fixture ────────────────────────────────────────────────────────
+
+
+def _generate_ticket_board(
+    tmp_path: Path,
+    *,
+    uikit: str = "my-ui",
+    status_field: str | None = None,
+    fields: list[dict] | None = None,
+) -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "board",
+        "label": "Ticket Board",
+        "resource": "ticket",
+        "type": "kanban",
+        "fields": fields
+        if fields is not None
+        else [
+            {"name": "title", "type": "string"},
+            {"name": "assignee", "type": "string"},
+            {"name": "priority", "type": "enum", "values": ["low", "medium", "high"]},
+            {"name": "status", "type": "enum", "values": ["todo", "inProgress", "done"]},
+            {"name": "dueDate", "type": "date"},
+        ],
+    }
+    if status_field:
+        page["statusField"] = status_field
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "BoardPage.tsx").read_text()
+
+
+# ── Status-field resolution ────────────────────────────────────────────────
+
+
+def test_kanban_prefers_field_named_status_when_multiple_enums_exist(tmp_path: Path) -> None:
+    """`priority` is the first enum in declaration order, but `status` wins by name."""
+    tsx = _generate_ticket_board(tmp_path)
+    assert 'STATUSES = ["todo", "inProgress", "done"] as const;' in tsx
+    # priority's values must NOT be the column set
+    assert 'STATUSES = ["low", "medium", "high"]' not in tsx
+
+
+def test_kanban_explicit_status_field_wins_over_name_heuristic(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path, status_field="priority")
+    assert 'STATUSES = ["low", "medium", "high"]' in tsx
+
+
+def test_kanban_falls_back_to_first_enum_when_no_status_like_name(tmp_path: Path) -> None:
+    """With no status/state/stage/phase, the first enum with values wins."""
+    tsx = _generate_ticket_board(
+        tmp_path,
+        fields=[
+            {"name": "title", "type": "string"},
+            {"name": "severity", "type": "enum", "values": ["low", "high"]},
+        ],
+    )
+    assert 'STATUSES = ["low", "high"]' in tsx
+
+
+def test_kanban_falls_back_to_single_backlog_column_when_no_enum(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(
+        tmp_path,
+        fields=[
+            {"name": "title", "type": "string"},
+            {"name": "assignee", "type": "string"},
+        ],
+    )
+    assert 'STATUSES = ["Backlog"]' in tsx
+
+
+# ── Data fetch + mutation ──────────────────────────────────────────────────
+
+
+def test_kanban_fetches_flat_list_with_large_page_size(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    assert "useQuery<PageResponse<Ticket>>" in tsx
+    assert 'size: "1000"' in tsx
+    assert '"ticket", "kanban"' in tsx
+
+
+def test_kanban_patch_mutation_updates_status_field(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # Sends a PATCH with the status field set to the new column value
+    assert "api.patch<Ticket>(`/ticket/${id}`, { status: status }" in tsx
+    # Invalidates the resource's caches after the mutation settles
+    assert 'queryClient.invalidateQueries({ queryKey: ["ticket"] })' in tsx
+
+
+# ── Optimistic move + rollback surface ─────────────────────────────────────
+
+
+def test_kanban_keeps_local_mirror_of_records_for_optimistic_moves(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # Local state + useEffect sync keeps the UI responsive without waiting on fetches
+    assert "const [local, setLocal] = useState<Ticket[]>([])" in tsx
+    assert "if (data) setLocal(data.content ?? [])" in tsx
+
+
+def test_kanban_drag_end_moves_card_locally_before_patch(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # Optimistic update before mutation.mutate
+    assert "setLocal((prev) =>" in tsx
+    assert "{ ...it, status: target }" in tsx
+    assert "mutation.mutate({ id, status: target })" in tsx
+
+
+def test_kanban_drop_on_non_column_is_noop(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # Guards against drops outside a registered column
+    assert "if (!over) return;" in tsx
+    assert "if (!STATUSES.includes(target)) return;" in tsx
+
+
+# ── dnd-kit wiring ─────────────────────────────────────────────────────────
+
+
+def test_kanban_imports_dnd_kit(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    assert 'from "@dnd-kit/core"' in tsx
+    assert 'from "@dnd-kit/sortable"' in tsx
+    assert 'from "@dnd-kit/utilities"' in tsx
+    for sym in [
+        "DndContext",
+        "PointerSensor",
+        "useSensor",
+        "SortableContext",
+        "verticalListSortingStrategy",
+        "useSortable",
+    ]:
+        assert sym in tsx, f"missing dnd-kit symbol: {sym}"
+
+
+def test_kanban_uses_pointer_sensor_with_activation_distance(tmp_path: Path) -> None:
+    """4px activation distance — small enough to feel responsive, big enough to
+    not fire on accidental clicks."""
+    tsx = _generate_ticket_board(tmp_path)
+    assert "activationConstraint: { distance: 4 }" in tsx
+
+
+def test_kanban_one_sortable_context_per_column(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # A SortableContext mapped over STATUSES.map((status) => ...)
+    assert "<SortableContext" in tsx
+    assert "strategy={verticalListSortingStrategy}" in tsx
+
+
+# ── Card rendering ─────────────────────────────────────────────────────────
+
+
+def test_kanban_card_title_comes_from_first_string_field_other_than_status(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # title is the first string field (status is enum so isn't eligible)
+    assert "{String(item.title ?? item.id)}" in tsx
+
+
+def test_kanban_card_body_hides_title_and_status_fields(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    # dt labels for body fields
+    for label in ["Assignee", "Priority", "Due Date"]:
+        assert f">{label}<" in tsx
+    # title + status are consumed by the header / column, so no dt for them
+    assert ">Title<" not in tsx
+    assert ">Status<" not in tsx
+
+
+def test_kanban_card_formats_dates_and_decimals(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path)
+    assert "new Date(item.dueDate).toLocaleDateString()" in tsx
+
+
+# ── Column header ─────────────────────────────────────────────────────────
+
+
+def test_kanban_column_header_shows_count(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path, uikit="my-ui")
+    # ui-kit branch: count inside a Badge
+    assert '<Badge variant="secondary">{items.length}</Badge>' in tsx
+
+
+def test_kanban_plain_branch_shows_count_without_badge(tmp_path: Path) -> None:
+    tsx = _generate_ticket_board(tmp_path, uikit="")
+    assert "Badge" not in tsx
+    # Still renders the count, just as a plain styled span
+    assert "rounded-full bg-muted" in tsx


### PR DESCRIPTION
## Summary

Sixth Phase 2 page type — **`kanban`**: a drag-and-drop board grouped by a status enum. Dropping a card into a different column PATCHes the record's status field and **optimistically moves the card locally** so the UI never lags while the mutation is in flight.

## Column resolution

1. Explicit `statusField` in the page config wins
2. Otherwise prefer an enum field whose name matches a status-y hint: `status` / `state` / `stage` / `phase` — matches nearly every kanban board in the wild, so auto-detection picks the right field when a resource has multiple enums (e.g. `priority` alongside `status`)
3. Fall back to the first enum field with a `values` array
4. No enum at all → single "Backlog" column containing every record (graceful fallback, not a hard error)

## Drag + drop wiring

- `@dnd-kit/core` `DndContext` wraps the board
- One `SortableContext` per column, `verticalListSortingStrategy`
- `PointerSensor` with `distance: 4` activation — small enough to feel responsive, big enough to avoid firing on accidental clicks
- `onDragEnd` guards: no-op if dropped outside a column or on an unknown status
- Optimistic local update before the PATCH; mutation invalidates the resource queryKey on settle, so a failed PATCH refetches and the UI heals

## Card rendering

| Slot | Content |
|---|---|
| Title | First string field other than the status field |
| Body rows | Every remaining field as compact label/value pairs |
| Formatting | `decimal → toFixed(2)` · `date → toLocaleDateString()` · `boolean → t("yes")/t("no")` · fallback → `?? "—"` |

Status field is consumed by the column header — not repeated on the card.

## Deps

Added to `frontend-app`'s runtime dependencies:

- `@dnd-kit/core` (^6.1.0)
- `@dnd-kit/sortable` (^8.0.0)
- `@dnd-kit/utilities` (^3.2.2)

All MIT, tree-shakable, zero peer conflicts with our React 18 setup.

## Example page config

```json
{
  "path": "board",
  "label": "Ticket Board",
  "resource": "ticket",
  "type": "kanban",
  "fields": [
    {"name": "title",    "type": "string"},
    {"name": "assignee", "type": "string"},
    {"name": "priority", "type": "enum", "values": ["low", "medium", "high"]},
    {"name": "status",   "type": "enum", "values": ["todo", "inProgress", "done"]},
    {"name": "dueDate",  "type": "date"}
  ]
}
```

Auto-picks `status` over `priority` thanks to the name-hint heuristic. Columns are **Todo / In Progress / Done**; cards show the title + assignee + priority + due date; dropping across columns patches `status`.

## Test plan

- [x] 18 new tests in `tests/test_page_types_kanban.py`:
  - Registration + metadata
  - **Status resolution**: name heuristic wins over first-enum, explicit wins over hint, first-enum when no hint, "Backlog" fallback
  - Paginated fetch with kanban-scoped queryKey
  - PATCH mutation body + cache invalidation on settle
  - Optimistic local mirror (useState + useEffect sync)
  - `onDragEnd` guards (no over / unknown status) + optimistic setLocal before mutation
  - dnd-kit imports + `PointerSensor` activation distance + one `SortableContext` per column
  - Card title from first non-status string field
  - Body skips title + status fields, includes all others
  - Type-aware formatting (date/decimal/boolean)
  - Column header with Badge count (ui-kit) vs plain pill (fallback)
- [x] **Full suite: 200/200 passing** (182 pre-existing + 18 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated a full ui-kit + api-client + frontend-app fixture with a kanban page; `vite build` succeeds.

## Docs

- `CLAUDE.md` — new `kanban` entry under **Page types**; `pages/` tree extended

## Phase 2 progress

6/7 landed: ~~`detail`~~ ✅ · ~~`grid`~~ ✅ · ~~`edit`~~ ✅ · ~~`settings`~~ ✅ · ~~`tree`~~ ✅ · ~~`kanban`~~ ✅ · `calendar` 🔜
