### PR TITLE
feat(pages): add `calendar` page type — schedule-x month/week/day view (Phase 2 complete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `settings` — configuration form for a **singleton** resource. `GET /{resource}` returns one record, `PUT /{resource}` updates it — no `id` in the URL. Fields can be grouped via an optional `group` key and render as shadcn `Accordion` items (Phase 0), all expanded by default; ungrouped fields drop into a "General" section. Plain-HTML fallback uses bordered `<section>` headings instead of Accordion. No delete.
 - `tree` — hierarchical view for a resource with a nullable `parentId` field. Fetches up to 1000 records via `GET /{resource}`, builds a nested tree client-side (dangling children become roots if pagination cuts off an ancestor), renders with [`react-arborist`](https://github.com/brimdata/react-arborist) — collapsible, keyboard-navigable, virtualized. Node label = first string field (falls back to `id`). Clicking a leaf navigates to `./view?id={id}` (the detail-page convention). Requires `react-arborist` (auto-added to frontend-app `dependencies`).
 - `kanban` — drag-and-drop board grouped by a status enum. Columns are the enum's `values`; dropping a card PATCHes the record's status field with the new column value, with an optimistic local update so the UI never lags. Column resolution: explicit `statusField` > field named `status`/`state`/`stage`/`phase` > first enum field > single "Backlog" fallback. Uses [`@dnd-kit/core`](https://dndkit.com/) + `@dnd-kit/sortable` + `@dnd-kit/utilities` — one `SortableContext` per column, 4 px pointer-activation distance.
+- `calendar` — month / week / day calendar view via [`@schedule-x/react`](https://schedule-x.dev/). Fetches up to 1000 records and transforms them into schedule-x events. Date-field resolution: explicit `dateField` > field named `date`/`startDate`/`start`/`when` > first `date`/`datetime` field. Optional `endField` falls back to the next temporal field, or to the same field as start (single-cell event). Title = first string field (or `id`). `datetime` values are sliced to 16 chars and the ISO `T` separator is swapped for a space to match schedule-x's `YYYY-MM-DD HH:mm` format; `date` values are sliced to 10 chars. Records with null start are skipped. Graceful placeholder when the resource has no `date`/`datetime` field.
 
 **Smart form features:**
 - `enum` fields with `values` array → `<select>` dropdown with predefined options
@@ -199,7 +200,8 @@ src/apps_generator/
 │       │   ├── edit_type.py
 │       │   ├── settings_type.py
 │       │   ├── tree_type.py
-│       │   └── kanban_type.py
+│       │   ├── kanban_type.py
+│       │   └── calendar_type.py
 │       ├── resources.py      # Java CRUD scaffolding
 │       ├── types.py          # TypeScript type generation
 │       ├── migrations.py     # Liquibase migrations
@@ -245,7 +247,7 @@ All templates use the shadcn neutral theme (near-black primary, not blue):
 - Translation files: `src/i18n/locales/en.json` and `fr.json`
 - Shell syncs language to MFEs via `window.__SHELL_LANGUAGE__` + event
 - All UI strings use `t("key")` — no hardcoded English in components
-- Generated pages (list/form/dashboard/detail/grid/edit/settings/tree/kanban) use `useTranslation()` for all UI text
+- Generated pages (list/form/dashboard/detail/grid/edit/settings/tree/kanban/calendar) use `useTranslation()` for all UI text
 - Translation keys: loading, noDataFound, previous, next, create, creating, createdSuccessfully, failedToLoad, etc.
 
 **Adding a new language:** Copy `en.json` to `<lang>.json`, translate values, add to `i18n/index.ts` resources.

--- a/src/apps_generator/cli/generators/pages/__init__.py
+++ b/src/apps_generator/cli/generators/pages/__init__.py
@@ -38,6 +38,7 @@ _BUILTIN_TYPES = (
     "settings_type",
     "tree_type",
     "kanban_type",
+    "calendar_type",
 )
 for _name in _BUILTIN_TYPES:
     import_module(f"{__name__}.{_name}")

--- a/src/apps_generator/cli/generators/pages/calendar_type.py
+++ b/src/apps_generator/cli/generators/pages/calendar_type.py
@@ -1,0 +1,224 @@
+"""``calendar`` page type — month/week/day calendar view via schedule-x.
+
+Transforms records into `schedule-x`_ event objects and renders them in
+a multi-view calendar (month grid, week, day). Suited for attendance,
+leave requests, bookings, deadlines — anything with a primary date and
+an optional end date.
+
+Field picking
+-------------
+1. **Date field** (required) — the event start. Resolution order:
+
+   a. Explicit ``dateField`` in the page config
+   b. First field named ``date``/``startDate``/``start``/``when`` with
+      a ``date`` or ``datetime`` type
+   c. First ``date``/``datetime`` field
+
+   The emitter refuses to generate a meaningful calendar if no date or
+   datetime field is available — the page falls back to a read-only
+   "No date field configured" notice.
+
+2. **End field** (optional) — event end. Defaults to explicit
+   ``endField`` or the next ``date``/``datetime`` field after the start.
+
+3. **Title field** — first ``string`` field (what shows in the event
+   pill). Falls back to the record id.
+
+.. _schedule-x: https://schedule-x.dev/
+"""
+
+from __future__ import annotations
+
+from apps_generator.utils.naming import camel_case, pascal_case
+
+from .base import page_target
+from .registry import PageContext, PageTypeInfo, get_registry
+
+
+_DATE_NAME_HINTS = ("date", "startdate", "start", "when")
+
+
+def _is_temporal(f: dict) -> bool:
+    return f.get("type") in ("date", "datetime")
+
+
+def _pick_date_field(page: dict, fields: list[dict]) -> dict | None:
+    explicit = page.get("dateField")
+    if explicit:
+        for f in fields:
+            if f.get("name") == explicit:
+                return f
+    for f in fields:
+        if _is_temporal(f) and f["name"].lower() in _DATE_NAME_HINTS:
+            return f
+    for f in fields:
+        if _is_temporal(f):
+            return f
+    return None
+
+
+def _pick_end_field(page: dict, fields: list[dict], start: dict | None) -> dict | None:
+    explicit = page.get("endField")
+    if explicit:
+        for f in fields:
+            if f.get("name") == explicit:
+                return f
+    for f in fields:
+        if f is start:
+            continue
+        if _is_temporal(f):
+            return f
+    return None
+
+
+def _pick_title_field(fields: list[dict]) -> dict | None:
+    for f in fields:
+        if f.get("type", "string") == "string":
+            return f
+    return None
+
+
+def _date_js_expr(field: dict, record_var: str) -> str:
+    """JS expression that converts a record's value into schedule-x's date format.
+
+    schedule-x expects ``YYYY-MM-DD`` (all-day) or ``YYYY-MM-DD HH:mm``
+    (timed). Date strings coming from the API are ISO-ish (``YYYY-MM-DD``
+    for dates, ``YYYY-MM-DDTHH:mm:ss[.sss][Z]`` for datetimes).
+    """
+    fname = camel_case(field["name"])
+    if field.get("type") == "datetime":
+        # datetime → slice first 16 chars, swap 'T' for a space
+        return f'String({record_var}.{fname}).slice(0, 16).replace("T", " ")'
+    # date → slice first 10 chars (already YYYY-MM-DD)
+    return f"String({record_var}.{fname}).slice(0, 10)"
+
+
+def emit_calendar(page: dict, ctx: PageContext) -> None:
+    dest, component, label = page_target(page, ctx)
+    resource = page.get("resource", "")
+    fields = page.get("fields", [])
+    entity = pascal_case(resource)
+    _api_pkg = ctx.api_client_name or "my-api-client"
+    ui = ctx.uikit_name
+
+    start_field = _pick_date_field(page, fields)
+    end_field = _pick_end_field(page, fields, start_field)
+    title_field = _pick_title_field(fields)
+
+    # No temporal field at all — emit a graceful placeholder. Better than a
+    # broken calendar that crashes at runtime.
+    if start_field is None:
+        dest.write_text(
+            f'import {{ useTranslation }} from "react-i18next";\n'
+            f"\n"
+            f"export function {component}() {{\n"
+            f"  const {{ t }} = useTranslation();\n"
+            f"  return (\n"
+            f'    <div className="space-y-4">\n'
+            f'      <h1 className="text-2xl font-bold tracking-tight">{label}</h1>\n'
+            f'      <p className="text-destructive">\n'
+            f'        {{t("calendarNeedsDateField")}}\n'
+            f"      </p>\n"
+            f"    </div>\n"
+            f"  );\n"
+            f"}}\n"
+        )
+        return
+
+    start_expr = _date_js_expr(start_field, "item")
+    end_expr = _date_js_expr(end_field, "item") if end_field else start_expr
+    title_expr = f"String(item.{camel_case(title_field['name'])} ?? item.id)" if title_field else "String(item.id)"
+
+    # ui-kit imports — calendar leans on Card for outer chrome; the grid
+    # itself is schedule-x regardless of --uikit.
+    if ui:
+        ui_import = f'import {{ Card, CardContent, CardHeader, CardTitle }} from "{ui}";\n'
+        wrapper_open = (
+            f"      <Card>\n"
+            f"        <CardHeader>\n"
+            f"          <CardTitle>{label} ({{items.length}})</CardTitle>\n"
+            f"        </CardHeader>\n"
+            f"        <CardContent>"
+        )
+        wrapper_close = "        </CardContent>\n      </Card>"
+    else:
+        ui_import = ""
+        wrapper_open = (
+            f'      <h1 className="text-2xl font-bold tracking-tight mb-4">{label} ({{items.length}})</h1>\n'
+            f'      <div className="rounded-lg border p-4">'
+        )
+        wrapper_close = "      </div>"
+
+    dest.write_text(
+        f'import {{ useMemo }} from "react";\n'
+        f'import {{ useTranslation }} from "react-i18next";\n'
+        f'import {{ useQuery }} from "@tanstack/react-query";\n'
+        f'import {{ ScheduleXCalendar, useCalendarApp }} from "@schedule-x/react";\n'
+        f'import {{ createViewMonthGrid, createViewWeek, createViewDay }} from "@schedule-x/calendar";\n'
+        f'import "@schedule-x/theme-default/dist/index.css";\n'
+        f'import {{ useApiClient }} from "{_api_pkg}/react";\n'
+        f'import type {{ {entity}, PageResponse }} from "{_api_pkg}";\n'
+        f"{ui_import}"
+        f"\n"
+        f"interface CalendarEvent {{\n"
+        f"  id: string;\n"
+        f"  title: string;\n"
+        f"  start: string;\n"
+        f"  end: string;\n"
+        f"}}\n"
+        f"\n"
+        f"export function {component}() {{\n"
+        f"  const {{ t }} = useTranslation();\n"
+        f"  const api = useApiClient();\n"
+        f"\n"
+        f"  const {{ data, isLoading, error }} = useQuery<PageResponse<{entity}>>({{  \n"
+        f'    queryKey: ["{resource}", "calendar"],\n'
+        f'    queryFn: () => api.get<PageResponse<{entity}>>("/{resource}", '
+        f'{{ params: {{ page: "0", size: "1000" }} }}),\n'
+        f"  }});\n"
+        f"\n"
+        f"  const items = data?.content ?? [];\n"
+        f"\n"
+        f"  const events = useMemo<CalendarEvent[]>(() => {{\n"
+        f"    const out: CalendarEvent[] = [];\n"
+        f"    for (const item of items) {{\n"
+        f"      const start = item.{camel_case(start_field['name'])};\n"
+        f"      if (start == null) continue;\n"
+        f"      out.push({{\n"
+        f"        id: String(item.id),\n"
+        f"        title: {title_expr},\n"
+        f"        start: {start_expr},\n"
+        f"        end: {end_expr},\n"
+        f"      }});\n"
+        f"    }}\n"
+        f"    return out;\n"
+        f"  }}, [items]);\n"
+        f"\n"
+        f"  const calendar = useCalendarApp({{\n"
+        f"    views: [createViewMonthGrid(), createViewWeek(), createViewDay()],\n"
+        f"    events,\n"
+        f"  }});\n"
+        f"\n"
+        f'  if (isLoading) return <p className="text-muted-foreground">{{t("loading")}}</p>;\n'
+        f'  if (error) return <p className="text-destructive">'
+        f'{{t("failedToLoad")}}: {{(error as Error).message}}</p>;\n'
+        f"\n"
+        f"  return (\n"
+        f'    <div className="space-y-4">\n'
+        f"{wrapper_open}\n"
+        f"          <ScheduleXCalendar calendarApp={{calendar}} />\n"
+        f"{wrapper_close}\n"
+        f"    </div>\n"
+        f"  );\n"
+        f"}}\n"
+    )
+
+
+PAGE_TYPE = PageTypeInfo(
+    name="calendar",
+    description="Month / week / day calendar view via schedule-x — records transformed to events by a date field.",
+    emit=emit_calendar,
+    required_fields=["resource"],
+)
+
+get_registry().register(PAGE_TYPE)

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/package.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/package.json
@@ -26,7 +26,10 @@
     "react-arborist": "^3.4.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
-    "@dnd-kit/utilities": "^3.2.2"
+    "@dnd-kit/utilities": "^3.2.2",
+    "@schedule-x/react": "^2.0.0",
+    "@schedule-x/calendar": "^2.0.0",
+    "@schedule-x/theme-default": "^2.0.0"
   },
   "devDependencies": {
     "@module-federation/vite": "^1.14.0",

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/en.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/en.json
@@ -27,5 +27,6 @@
   "confirmDelete": "Are you sure?",
   "confirmDeleteDesc": "This action cannot be undone.",
   "confirm": "Confirm",
-  "cancel": "Cancel"
+  "cancel": "Cancel",
+  "calendarNeedsDateField": "This calendar has no date field configured."
 }

--- a/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/fr.json
+++ b/src/apps_generator/templates/builtin/frontend_app/files/__projectName__/src/i18n/locales/fr.json
@@ -27,5 +27,6 @@
   "confirmDelete": "Êtes-vous sûr ?",
   "confirmDeleteDesc": "Cette action est irréversible.",
   "confirm": "Confirmer",
-  "cancel": "Annuler"
+  "cancel": "Annuler",
+  "calendarNeedsDateField": "Ce calendrier n'a pas de champ de date configuré."
 }

--- a/tests/test_page_types_calendar.py
+++ b/tests/test_page_types_calendar.py
@@ -1,0 +1,235 @@
+"""Tests for the ``calendar`` page type — schedule-x month/week/day view."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apps_generator.cli.generators.pages import (
+    generate_page_components,
+    get_registry,
+)
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+
+def test_calendar_type_is_registered() -> None:
+    info = get_registry().get("calendar")
+    assert info is not None
+    assert info.source == "builtin"
+    assert info.required_fields == ["resource"]
+    assert info.description
+
+
+# ── Emitter fixture ────────────────────────────────────────────────────────
+
+
+def _generate_attendance_calendar(
+    tmp_path: Path,
+    *,
+    uikit: str = "my-ui",
+    fields: list[dict] | None = None,
+    date_field: str | None = None,
+    end_field: str | None = None,
+) -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "cal",
+        "label": "Attendance Calendar",
+        "resource": "attendance",
+        "type": "calendar",
+        "fields": fields
+        if fields is not None
+        else [
+            {"name": "employeeName", "type": "string"},
+            {"name": "date", "type": "date"},
+            {"name": "endDate", "type": "date"},
+            {"name": "type", "type": "enum", "values": ["vacation", "sick", "remote"]},
+        ],
+    }
+    if date_field:
+        page["dateField"] = date_field
+    if end_field:
+        page["endField"] = end_field
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "CalPage.tsx").read_text()
+
+
+# ── Date-field resolution ──────────────────────────────────────────────────
+
+
+def test_calendar_prefers_field_named_date_when_multiple_temporals_exist(tmp_path: Path) -> None:
+    """`date` wins over `endDate` (both are `date`) because of the name hint."""
+    tsx = _generate_attendance_calendar(tmp_path)
+    # Start uses `date`, end uses `endDate`
+    assert "const start = item.date;" in tsx
+    assert "start: String(item.date).slice(0, 10)" in tsx
+    assert "end: String(item.endDate).slice(0, 10)" in tsx
+
+
+def test_calendar_explicit_date_field_wins(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "employeeName", "type": "string"},
+            {"name": "checkIn", "type": "datetime"},
+            {"name": "checkOut", "type": "datetime"},
+        ],
+        date_field="checkIn",
+    )
+    assert "const start = item.checkIn;" in tsx
+    # datetime → 16-char slice + T→space
+    assert 'start: String(item.checkIn).slice(0, 16).replace("T", " ")' in tsx
+
+
+def test_calendar_explicit_end_field_wins(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "employeeName", "type": "string"},
+            {"name": "from", "type": "date"},
+            {"name": "until", "type": "date"},
+            {"name": "auditDate", "type": "date"},
+        ],
+        date_field="from",
+        end_field="until",
+    )
+    assert "end: String(item.until).slice(0, 10)" in tsx
+
+
+def test_calendar_end_defaults_to_start_when_only_one_temporal(tmp_path: Path) -> None:
+    """Single-date events — end == start so schedule-x renders a 1-cell event."""
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "title", "type": "string"},
+            {"name": "date", "type": "date"},
+        ],
+    )
+    # end should mirror start
+    assert "start: String(item.date).slice(0, 10)" in tsx
+    assert "end: String(item.date).slice(0, 10)" in tsx
+
+
+def test_calendar_falls_back_to_first_temporal_when_no_name_hint(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "title", "type": "string"},
+            {"name": "notifyAt", "type": "datetime"},
+        ],
+    )
+    assert "const start = item.notifyAt;" in tsx
+
+
+# ── Graceful fallback when no temporal field ───────────────────────────────
+
+
+def test_calendar_with_no_date_field_emits_placeholder(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "title", "type": "string"},
+            {"name": "description", "type": "text"},
+        ],
+    )
+    # No schedule-x wiring — just the "needs a date field" notice
+    assert "@schedule-x/react" not in tsx
+    assert "ScheduleXCalendar" not in tsx
+    assert 't("calendarNeedsDateField")' in tsx
+
+
+# ── Data fetch + transform ─────────────────────────────────────────────────
+
+
+def test_calendar_fetches_flat_list_with_large_page_size(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path)
+    assert "useQuery<PageResponse<Attendance>>" in tsx
+    assert 'size: "1000"' in tsx
+    assert '"attendance", "calendar"' in tsx
+
+
+def test_calendar_skips_records_with_null_start(tmp_path: Path) -> None:
+    """Schedule-x chokes if an event's start is null — drop the record."""
+    tsx = _generate_attendance_calendar(tmp_path)
+    assert "if (start == null) continue;" in tsx
+
+
+def test_calendar_event_title_uses_first_string_field(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path)
+    assert "title: String(item.employeeName ?? item.id)" in tsx
+
+
+def test_calendar_event_title_falls_back_to_id_when_no_string(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "date", "type": "date"},
+            {"name": "endDate", "type": "date"},
+        ],
+    )
+    assert "title: String(item.id)" in tsx
+
+
+def test_calendar_events_memoized_so_useCalendarApp_is_stable(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path)
+    assert "useMemo<CalendarEvent[]>(() => {" in tsx
+    assert "}, [items]);" in tsx
+
+
+# ── schedule-x wiring ──────────────────────────────────────────────────────
+
+
+def test_calendar_imports_schedule_x(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path)
+    assert 'from "@schedule-x/react"' in tsx
+    assert 'from "@schedule-x/calendar"' in tsx
+    assert 'import "@schedule-x/theme-default/dist/index.css"' in tsx
+    assert "ScheduleXCalendar" in tsx
+    assert "useCalendarApp" in tsx
+
+
+def test_calendar_registers_month_week_day_views(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path)
+    assert "createViewMonthGrid()" in tsx
+    assert "createViewWeek()" in tsx
+    assert "createViewDay()" in tsx
+
+
+# ── Datetime formatting ────────────────────────────────────────────────────
+
+
+def test_calendar_datetime_field_slices_and_replaces_T(tmp_path: Path) -> None:
+    """schedule-x wants ``YYYY-MM-DD HH:mm`` — ISO's ``T`` separator must go."""
+    tsx = _generate_attendance_calendar(
+        tmp_path,
+        fields=[
+            {"name": "title", "type": "string"},
+            {"name": "startsAt", "type": "datetime"},
+        ],
+    )
+    assert 'String(item.startsAt).slice(0, 16).replace("T", " ")' in tsx
+
+
+# ── Wrappers ───────────────────────────────────────────────────────────────
+
+
+def test_calendar_uikit_branch_uses_card_wrapper(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path, uikit="my-ui")
+    assert 'from "my-ui"' in tsx
+    for sym in ["Card", "CardContent", "CardHeader", "CardTitle"]:
+        assert sym in tsx
+
+
+def test_calendar_plain_branch_uses_bordered_div(tmp_path: Path) -> None:
+    tsx = _generate_attendance_calendar(tmp_path, uikit="")
+    assert "Card" not in tsx
+    assert '<div className="rounded-lg border p-4">' in tsx
+    assert "Attendance Calendar ({items.length})" in tsx


### PR DESCRIPTION
## Summary

Seventh and final Phase 2 page type — **`calendar`**: a month / week / day calendar view via [`@schedule-x/react`](https://schedule-x.dev/). Transforms records into schedule-x events, suits attendance, leave requests, bookings, deadlines — anything with a primary date and an optional end date.

**This PR closes out Phase 2**: 10 total page types in the catalog (3 pre-existing + 7 new), full SmartHR skeleton coverage.

## Field resolution

| Role | Resolution order |
|---|---|
| **Date** (required) | explicit `dateField` → temporal field named `date`/`startDate`/`start`/`when` → first `date`/`datetime` field |
| **End** (optional) | explicit `endField` → next temporal after start → same as start (single-cell event) |
| **Title** | first `string` field → `id` |

No date/datetime field at all? The emitter bails gracefully and writes a read-only placeholder keyed on a new i18n string (`calendarNeedsDateField`) — better than a runtime crash.

## Date formatting

schedule-x expects `YYYY-MM-DD` (all-day) or `YYYY-MM-DD HH:mm` (timed). The emitter generates the right conversion per field type:

```ts
date     →  String(v).slice(0, 10)
datetime →  String(v).slice(0, 16).replace("T", " ")
```

Records with null start are skipped at transform time so schedule-x never sees a malformed event.

## Deps

Added to frontend-app runtime deps:

- `@schedule-x/react` (^2.0.0)
- `@schedule-x/calendar` (^2.0.0)
- `@schedule-x/theme-default` (^2.0.0) — CSS imported directly in the emitted page

## i18n

One new key in both `en.json` and `fr.json`:

| key | EN | FR |
|---|---|---|
| `calendarNeedsDateField` | This calendar has no date field configured. | Ce calendrier n'a pas de champ de date configuré. |

## Example page config

```json
{
  "path": "leaves",
  "label": "Leave Calendar",
  "resource": "leaveRequest",
  "type": "calendar",
  "fields": [
    {"name": "employeeName", "type": "string"},
    {"name": "startDate",    "type": "date"},
    {"name": "endDate",      "type": "date"},
    {"name": "type",         "type": "enum", "values": ["vacation", "sick", "remote"]}
  ]
}
```

Auto-picks `startDate` over `endDate` via the name hint. Title on each event is the employee name.

## Test plan

- [x] 17 new tests in `tests/test_page_types_calendar.py`:
  - Registration + metadata
  - Date-field resolution (name hint, explicit, first temporal)
  - Explicit + auto `endField` + end-defaults-to-start edge case
  - No-date-field graceful fallback (no schedule-x wiring, i18n placeholder)
  - Paginated fetch with calendar-scoped queryKey
  - Null-start records skipped
  - Title from first string, `id` fallback
  - `useMemo` wrapping
  - schedule-x imports + month/week/day views
  - Datetime slice + `T` → space conversion
  - ui-kit Card wrapper + plain bordered div wrapper
- [x] **Full suite: 217/217 passing** (200 pre-existing + 17 new)
- [x] **Ruff clean** (check + format)
- [x] **End-to-end verified**: generated ui-kit + api-client + frontend-app with a calendar page; `vite build` succeeds.

## Docs

- `CLAUDE.md` — new `calendar` entry; `pages/` tree extended

## Phase 2: complete

**10 page types total — all green:**

| | Type | Lib |
|---|---|---|
| ✅ | `list`  | (pre-existing) |
| ✅ | `form`  | (pre-existing) |
| ✅ | `dashboard`  | recharts |
| ✅ | `detail` | — |
| ✅ | `grid`  | — |
| ✅ | `edit`  | (Phase 0: AlertDialog) |
| ✅ | `settings` | (Phase 0: Accordion) |
| ✅ | `tree`  | react-arborist |
| ✅ | `kanban` | @dnd-kit/* |
| ✅ | `calendar` | @schedule-x/react |

SmartHR skeleton coverage goal from the original feasibility analysis: **met**.
