### PR TITLE
feat(resources): add `reference` field type — FK relations across resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,11 @@ Features: `database` (on), `oauth2` (on), `docker` (on), `kubernetes` (on), `cic
 }]
 ```
 
-**Field types:** string, text, integer, long, decimal, boolean, date, datetime, enum.
+**Field types:** string, text, integer, long, decimal, boolean, date, datetime, enum, **reference**.
 
 **Enum fields** use a `values` array: `{"name": "status", "type": "enum", "values": ["active", "inactive"]}`. Generates Java enum class, `@Enumerated(EnumType.STRING)` on entity, TypeScript union type (`"active" | "inactive"`), and `<select>` dropdown in forms.
+
+**Reference fields** use a `target` pointing at another resource: `{"name": "departmentId", "type": "reference", "target": "department"}`. Generates a `Long` FK column on the entity (no `@ManyToOne` navigation — DTOs stay flat), a Liquibase `addForeignKeyConstraint` pointing at `{target}s(id)`, and a TypeScript `number` in the Create/Update/Response DTOs. Self-references are allowed (e.g. `department.parentId → department`) and power the `tree` page without the caller having to add `parentId` by hand. The `form` / `edit` pages auto-render a `reference` as a **Combobox** lookup against the target's list endpoint. Cross-resource references require the target resource to appear earlier in the `resources` array so its table exists when the FK is applied.
 
 **Constraints:** required, unique, maxLength, minLength, min, max, pattern.
 
@@ -140,7 +142,7 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `grid` — responsive card-grid (1 col mobile / 2 md / 3 lg) for a resource collection. Same paginated query as `list`. First string field becomes the CardTitle, second becomes CardDescription; remaining fields drop into the card body as label/value pairs. Enum and boolean values render as Badges for fast visual scanning. Null-safe, shows empty state spanning all grid columns.
 - `edit` — update form for an existing record. Reads `id` from `?id=` query string, fetches via `useQuery`, hydrates form state via `useEffect`, saves via PUT with `t("updatedSuccessfully")` feedback. Includes a destructive Delete button wrapped in an `AlertDialog` confirmation (Phase 0 component); plain-HTML fallback uses `window.confirm`. Same type-aware inputs and resource-lookup auto-detection as `form`.
 - `settings` — configuration form for a **singleton** resource. `GET /{resource}` returns one record, `PUT /{resource}` updates it — no `id` in the URL. Fields can be grouped via an optional `group` key and render as shadcn `Accordion` items (Phase 0), all expanded by default; ungrouped fields drop into a "General" section. Plain-HTML fallback uses bordered `<section>` headings instead of Accordion. No delete.
-- `tree` — hierarchical view for a resource with a nullable `parentId` field. Fetches up to 1000 records via `GET /{resource}`, builds a nested tree client-side (dangling children become roots if pagination cuts off an ancestor), renders with [`react-arborist`](https://github.com/brimdata/react-arborist) — collapsible, keyboard-navigable, virtualized. Node label = first string field (falls back to `id`). Clicking a leaf navigates to `./view?id={id}` (the detail-page convention). Requires `react-arborist` (auto-added to frontend-app `dependencies`).
+- `tree` — hierarchical view for a resource with a nullable self-reference field. Fetches up to 1000 records via `GET /{resource}`, builds a nested tree client-side (dangling children become roots if pagination cuts off an ancestor), renders with [`react-arborist`](https://github.com/brimdata/react-arborist) — collapsible, keyboard-navigable, virtualized. **Parent-field resolution:** first a `type: "reference"` field whose `target` equals the page's resource (preferred — use any name, e.g. `managerId`); otherwise a field literally named `parentId` (legacy convention). Node label = first string field (falls back to `id`). Clicking a leaf navigates to `./view?id={id}` (the detail-page convention). Requires `react-arborist` (auto-added to frontend-app `dependencies`).
 - `kanban` — drag-and-drop board grouped by a status enum. Columns are the enum's `values`; dropping a card PATCHes the record's status field with the new column value, with an optimistic local update so the UI never lags. Column resolution: explicit `statusField` > field named `status`/`state`/`stage`/`phase` > first enum field > single "Backlog" fallback. Uses [`@dnd-kit/core`](https://dndkit.com/) + `@dnd-kit/sortable` + `@dnd-kit/utilities` — one `SortableContext` per column, 4 px pointer-activation distance.
 - `calendar` — month / week / day calendar view via [`@schedule-x/react`](https://schedule-x.dev/). Fetches up to 1000 records and transforms them into schedule-x events. Date-field resolution: explicit `dateField` > field named `date`/`startDate`/`start`/`when` > first `date`/`datetime` field. Optional `endField` falls back to the next temporal field, or to the same field as start (single-cell event). Title = first string field (or `id`). `datetime` values are sliced to 16 chars and the ISO `T` separator is swapped for a space to match schedule-x's `YYYY-MM-DD HH:mm` format; `date` values are sliced to 10 chars. Records with null start are skipped. Graceful placeholder when the resource has no `date`/`datetime` field.
 
@@ -151,7 +153,11 @@ Features: `docker` (on), `kubernetes` (on), `cicd` (on), `tailwind` (on).
 - `enum` fields with `values` array → native `<select>` dropdown — enum value lists are short enough that a native picker stays usable.
 - `text` fields → `<textarea>`.
 - `boolean` fields → ui-kit `Checkbox` (with `--uikit`) or native checkbox.
-- **Resource lookups**: when a field name matches `{resource}Name` or `{resource}Id` and that resource exists in the pages config, the form auto-fetches and renders a ui-kit **`Combobox`** (typeahead, from Phase 0) when `--uikit` is linked — so the picker stays usable as the option list grows. Without ui-kit, falls back to a native `<select>`. Shows "Create one first" message when the referenced resource has no rows.
+- **Resource lookups**: two paths, in this order:
+  1. **Explicit** — a `type: "reference"` field with a `target` naming another resource (the first-class form). Self-references are supported (e.g. `department.parentId → department`).
+  2. **Heuristic** — name match like `{resource}Name` / `{resource}Id` against the pages-config resources (legacy convention; skips the current resource to avoid nonsense self-matches).
+
+  Either way, the form auto-fetches the target's list endpoint and renders a ui-kit **`Combobox`** (typeahead, from Phase 0) when `--uikit` is linked — so the picker stays usable as the option list grows. Without ui-kit, falls back to a native `<select>`. Shows "Create one first" message when the referenced resource has no rows.
 
 When `--uikit` is linked, pages import shadcn components (Button, Input, Table, Card, etc.). Without ui-kit, falls back to plain HTML with matching Tailwind classes.
 
@@ -241,6 +247,7 @@ src/apps_generator/
 | date | LocalDate | DATE | string |
 | datetime | LocalDateTime | TIMESTAMP | string |
 | enum | Java enum class | VARCHAR | union type (e.g. `"a" \| "b"`) |
+| reference | Long | BIGINT + FK | number |
 
 ## CSS theme
 

--- a/src/apps_generator/cli/generators/migrations.py
+++ b/src/apps_generator/cli/generators/migrations.py
@@ -98,15 +98,15 @@ def generate_migration(res_root: Path, entity: str, table: str, fields: list[dic
         if not target:
             continue
         target_table = snake_case(target) + "s"
-        col = snake_case(f["name"])
+        col_name = snake_case(f["name"])
         changeset["changes"].append(
             {
                 "addForeignKeyConstraint": {
                     "baseTableName": table,
-                    "baseColumnNames": col,
+                    "baseColumnNames": col_name,
                     "referencedTableName": target_table,
                     "referencedColumnNames": "id",
-                    "constraintName": f"fk_{table}_{col}",
+                    "constraintName": f"fk_{table}_{col_name}",
                 }
             }
         )

--- a/src/apps_generator/cli/generators/migrations.py
+++ b/src/apps_generator/cli/generators/migrations.py
@@ -87,6 +87,30 @@ def generate_migration(res_root: Path, entity: str, table: str, fields: list[dic
                 }
             )
 
+    # Foreign-key constraints for `reference` fields. The referenced table must
+    # already exist — self-references resolve against this same changeset's
+    # createTable; cross-resource references require the target resource to
+    # appear earlier in the resources array so its migration runs first.
+    for f in fields:
+        if f.get("type") != "reference":
+            continue
+        target = f.get("target")
+        if not target:
+            continue
+        target_table = snake_case(target) + "s"
+        col = snake_case(f["name"])
+        changeset["changes"].append(
+            {
+                "addForeignKeyConstraint": {
+                    "baseTableName": table,
+                    "baseColumnNames": col,
+                    "referencedTableName": target_table,
+                    "referencedColumnNames": "id",
+                    "constraintName": f"fk_{table}_{col}",
+                }
+            }
+        )
+
     migration_file.write_text(
         yaml.dump(
             {"databaseChangeLog": [{"changeSet": changeset}]},

--- a/src/apps_generator/cli/generators/pages/base.py
+++ b/src/apps_generator/cli/generators/pages/base.py
@@ -9,14 +9,42 @@ from apps_generator.utils.naming import pascal_case, title_case
 from .registry import PageContext
 
 
-def detect_lookup(field: dict, all_resources: list[str]) -> dict | None:
+def detect_lookup(
+    field: dict,
+    all_resources: list[str],
+    *,
+    current_resource: str | None = None,
+) -> dict | None:
     """Auto-detect if a field should be a lookup to another resource.
 
-    Matches patterns like ``dogName`` -> resource ``dog``, ``categoryId`` ->
-    resource ``category``. Returns a lookup config dict or ``None``.
+    Two paths, in order of preference:
+
+    1. **Explicit** — ``type: "reference"`` with a ``target`` naming another
+       resource. This is the first-class path: the caller has declared the
+       FK intent, so we honour it even when ``target == current_resource``
+       (self-references are the whole point of tree-style hierarchies).
+    2. **Heuristic** — name-based match for configs without an explicit
+       reference type: ``dogName`` → resource ``dog``, ``categoryId`` →
+       resource ``category``. ``current_resource`` is skipped here to
+       avoid nonsense self-matches on fields that happen to share a name
+       prefix with their own resource.
+
+    Returns a lookup config dict or ``None``.
     """
+    if field.get("type") == "reference":
+        target = field.get("target")
+        if target and target in all_resources:
+            # FK id lives on the entity; label picks the first string-ish field
+            # of the target by convention (``name``). Users can override via
+            # ``lookup.labelField`` in the page config if they've got a
+            # different display field.
+            return {"resource": target, "valueField": "id", "labelField": "name"}
+        return None
+
     fname = field["name"]
     for res in all_resources:
+        if current_resource is not None and res == current_resource:
+            continue
         res_lower = res.lower()
         fname_lower = fname.lower()
         if fname_lower in (f"{res_lower}name", f"{res_lower}id", f"{res_lower}_name", f"{res_lower}_id"):

--- a/src/apps_generator/cli/generators/pages/edit_type.py
+++ b/src/apps_generator/cli/generators/pages/edit_type.py
@@ -32,12 +32,14 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
     fields = page.get("fields", [])
 
     # Auto-detect lookups (same convention as form_type, mutating fields in
-    # place to preserve the existing contract).
+    # place to preserve the existing contract). Self-references (e.g. an
+    # ``employee.managerId`` pointing back at ``employee``) are preserved by
+    # passing the unfiltered resource list and letting ``detect_lookup``
+    # handle self-match policy per-branch.
     if ctx.all_resources:
-        other_resources = [r for r in ctx.all_resources if r != resource]
         for f in fields:
             if "lookup" not in f:
-                detected = detect_lookup(f, other_resources)
+                detected = detect_lookup(f, ctx.all_resources, current_resource=resource)
                 if detected:
                     f["lookup"] = detected
 
@@ -72,13 +74,15 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
 
     # State hydration — map each fetched field into the form. Numbers come
     # back as numbers from the API but the form state expects strings.
+    # Reference fields are stringified for the same reason — the Combobox
+    # option values are strings.
     hydrate_lines: list[str] = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
         if ft == "boolean":
             hydrate_lines.append(f"          {fname}: data.{fname} ?? false,")
-        elif ft in ("integer", "long", "decimal"):
+        elif ft in ("integer", "long", "decimal", "reference"):
             hydrate_lines.append(f'          {fname}: data.{fname} != null ? String(data.{fname}) : "",')
         elif ft == "datetime":
             # HTML datetime-local wants YYYY-MM-DDTHH:mm (no TZ) — trim any zone.
@@ -270,12 +274,13 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
 
     inputs_str = "\n".join(inputs)
 
-    # Body of the PUT — cast numeric fields back to numbers.
+    # Body of the PUT — cast numeric fields back to numbers. Reference
+    # fields are FK ids (backend ``Long``) so they share the Number cast.
     body_fields: list[str] = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
-        if ft in ("integer", "long", "decimal"):
+        if ft in ("integer", "long", "decimal", "reference"):
             body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
         elif ft == "boolean":
             body_fields.append(f"        {fname}: form.{fname},")

--- a/src/apps_generator/cli/generators/pages/form_type.py
+++ b/src/apps_generator/cli/generators/pages/form_type.py
@@ -16,11 +16,14 @@ def emit_form(page: dict, ctx: PageContext) -> None:
 
     # Auto-detect lookups (mutates page["fields"] in-place to preserve prior
     # behaviour — the old dispatcher did this before calling the emitter).
+    # Explicit ``reference`` fields are allowed to self-resolve (e.g. a
+    # department with a ``parentId`` reference back to ``department``); the
+    # name-heuristic branch inside ``detect_lookup`` skips the current
+    # resource to prevent nonsense matches.
     if ctx.all_resources:
-        other_resources = [r for r in ctx.all_resources if r != resource]
         for f in fields:
             if "lookup" not in f:
-                detected = detect_lookup(f, other_resources)
+                detected = detect_lookup(f, ctx.all_resources, current_resource=resource)
                 if detected:
                     f["lookup"] = detected
 
@@ -240,12 +243,14 @@ def emit_form(page: dict, ctx: PageContext) -> None:
 
     inputs_str = "\n".join(inputs)
 
-    # Build submission body (cast number fields)
+    # Build submission body (cast number fields). Reference fields are FK ids
+    # stored as ``Long`` on the backend, so they need the same Number cast as
+    # any other numeric type.
     body_fields = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
-        if ft in ("integer", "long", "decimal"):
+        if ft in ("integer", "long", "decimal", "reference"):
             body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
         elif ft == "boolean":
             body_fields.append(f"        {fname}: form.{fname},")

--- a/src/apps_generator/cli/generators/pages/settings_type.py
+++ b/src/apps_generator/cli/generators/pages/settings_type.py
@@ -219,13 +219,15 @@ def emit_settings(page: dict, ctx: PageContext) -> None:
     state_init = ", ".join(f"{k}: {v}" for k, v in defaults.items())
 
     # Hydration — same rules as edit_type: stringify numbers, slice datetime.
+    # Reference FK ids also stringify so the <input type="number"> round-trip
+    # works cleanly in the fallback renderer.
     hydrate_lines: list[str] = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
         if ft == "boolean":
             hydrate_lines.append(f"          {fname}: data.{fname} ?? false,")
-        elif ft in ("integer", "long", "decimal"):
+        elif ft in ("integer", "long", "decimal", "reference"):
             hydrate_lines.append(f'          {fname}: data.{fname} != null ? String(data.{fname}) : "",')
         elif ft == "datetime":
             hydrate_lines.append(f'          {fname}: data.{fname} ? String(data.{fname}).slice(0, 16) : "",')
@@ -233,12 +235,12 @@ def emit_settings(page: dict, ctx: PageContext) -> None:
             hydrate_lines.append(f'          {fname}: data.{fname} ?? "",')
     hydrate_str = "\n".join(hydrate_lines)
 
-    # Body of the PUT — cast numeric fields.
+    # Body of the PUT — cast numeric fields. Reference FK ids cast too.
     body_fields: list[str] = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
-        if ft in ("integer", "long", "decimal"):
+        if ft in ("integer", "long", "decimal", "reference"):
             body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
         elif ft == "boolean":
             body_fields.append(f"        {fname}: form.{fname},")

--- a/src/apps_generator/cli/generators/pages/tree_type.py
+++ b/src/apps_generator/cli/generators/pages/tree_type.py
@@ -1,16 +1,23 @@
 """``tree`` page type — hierarchical view of a self-referencing resource.
 
 Fetches a flat paginated list from the resource's collection endpoint,
-builds a tree from records whose ``parentId`` points to another record of
-the same resource, and renders it with `react-arborist`_. Nodes are
+builds a tree from records whose parent field points to another record
+of the same resource, and renders it with `react-arborist`_. Nodes are
 collapsible, keyboard-navigable, and virtualized — suitable for
 department hierarchies, folder structures, org charts, category trees.
 
 The resource must expose:
 
 * ``id`` — unique identifier (always present via ``TenantAwareEntity``)
-* ``parentId`` — nullable reference to another record of the same resource.
-  Records with ``parentId == null`` are roots.
+* a *parent field* — nullable reference to another record of the same
+  resource. Records where that field is ``null`` are roots.
+
+**Parent-field resolution**, in order:
+
+1. The first ``type: "reference"`` field whose ``target`` equals the
+   page's own resource — the first-class form (unblocked by PR C).
+2. A field literally named ``parentId`` / ``parent_id`` — legacy
+   convention, still honoured so older configs keep working.
 
 Clicking a node navigates to ``./view?id={id}`` by convention, so that a
 co-located ``detail`` page of the same resource opens that record. The
@@ -41,6 +48,23 @@ def emit_tree(page: dict, ctx: PageContext) -> None:
     # when no string field is configured.
     label_field = next((f for f in fields if f.get("type", "string") == "string"), None)
     label_fname = camel_case(label_field["name"]) if label_field else "id"
+
+    # Resolve the parent field — explicit self-reference takes priority over
+    # the legacy ``parentId`` convention.
+    parent_field = next(
+        (
+            f
+            for f in fields
+            if f.get("type") == "reference" and f.get("target") == resource
+        ),
+        None,
+    )
+    if parent_field is None:
+        parent_field = next(
+            (f for f in fields if f["name"] in ("parentId", "parent_id")),
+            None,
+        )
+    parent_fname = camel_case(parent_field["name"]) if parent_field else "parentId"
 
     # ui-kit imports — Tree pages lean on Card for the outer chrome; the
     # tree itself is react-arborist regardless of --uikit.
@@ -108,9 +132,10 @@ def emit_tree(page: dict, ctx: PageContext) -> None:
         f"}}\n"
         f"\n"
         f"/**\n"
-        f" * Build a nested tree from a flat list of records using ``parentId``.\n"
-        f" * Records whose parent isn't in the list are treated as roots so the\n"
-        f" * view degrades gracefully if pagination cuts off an ancestor.\n"
+        f" * Build a nested tree from a flat list of records using the parent\n"
+        f" * field resolved at generation time. Records whose parent isn't in\n"
+        f" * the list are treated as roots so the view degrades gracefully if\n"
+        f" * pagination cuts off an ancestor.\n"
         f" */\n"
         f"function buildTree(items: {entity}[]): TreeNode[] {{\n"
         f"  const byId = new Map<string, TreeNode>();\n"
@@ -124,8 +149,9 @@ def emit_tree(page: dict, ctx: PageContext) -> None:
         f"  const roots: TreeNode[] = [];\n"
         f"  for (const item of items) {{\n"
         f"    const node = byId.get(String(item.id))!;\n"
-        f"    const parentId = (item as unknown as {{ parentId?: string | number | null }}).parentId;\n"
-        f"    const parent = parentId != null ? byId.get(String(parentId)) : undefined;\n"
+        f"    const parentRef = (item as unknown as "
+        f"{{ {parent_fname}?: string | number | null }}).{parent_fname};\n"
+        f"    const parent = parentRef != null ? byId.get(String(parentRef)) : undefined;\n"
         f"    if (parent) parent.children!.push(node);\n"
         f"    else roots.push(node);\n"
         f"  }}\n"

--- a/src/apps_generator/cli/generators/pages/tree_type.py
+++ b/src/apps_generator/cli/generators/pages/tree_type.py
@@ -52,11 +52,7 @@ def emit_tree(page: dict, ctx: PageContext) -> None:
     # Resolve the parent field — explicit self-reference takes priority over
     # the legacy ``parentId`` convention.
     parent_field = next(
-        (
-            f
-            for f in fields
-            if f.get("type") == "reference" and f.get("target") == resource
-        ),
+        (f for f in fields if f.get("type") == "reference" and f.get("target") == resource),
         None,
     )
     if parent_field is None:

--- a/src/apps_generator/cli/generators/resources.py
+++ b/src/apps_generator/cli/generators/resources.py
@@ -21,6 +21,7 @@ JAVA_TYPES = {
     "date": "LocalDate",
     "datetime": "LocalDateTime",
     "enum": "__ENUM__",  # placeholder — replaced by generated enum class name
+    "reference": "Long",  # FK id pointing at another resource's id column
 }
 
 SQL_TYPES = {
@@ -33,6 +34,7 @@ SQL_TYPES = {
     "date": "DATE",
     "datetime": "TIMESTAMP",
     "enum": "VARCHAR({maxLength})",
+    "reference": "BIGINT",
 }
 
 TS_TYPES = {
@@ -45,6 +47,7 @@ TS_TYPES = {
     "date": "string",
     "datetime": "string",
     "enum": "__ENUM__",  # placeholder — replaced by union type
+    "reference": "number",
 }
 
 JAVA_IMPORTS = {
@@ -895,6 +898,16 @@ def _gen_integration_test(test_root: Path, pkg: str, entity: str, name: str, fie
             update_field = f
             break
 
+    # Required-field validation test needs a *simple* field we can safely drop.
+    # Reference fields depend on a pre-existing target row, which the test
+    # harness doesn't bootstrap — skip them here and the validation test is
+    # either generated against a simple required field or omitted entirely.
+    required_field = None
+    for f in fields:
+        if f.get("required") and f.get("type") != "reference":
+            required_field = f
+            break
+
     update_assertion = ""
     update_json = json_body
     if update_field:
@@ -904,12 +917,6 @@ def _gen_integration_test(test_root: Path, pkg: str, entity: str, name: str, fie
     else:
         update_assertion = ";"
 
-    # Find a required field name for validation test
-    required_field = None
-    for f in fields:
-        if f.get("required"):
-            required_field = f
-            break
     validation_test = ""
     if required_field:
         # Build JSON with required field missing

--- a/tests/test_reference_field_type.py
+++ b/tests/test_reference_field_type.py
@@ -1,0 +1,458 @@
+"""Tests for the ``reference`` field type — FK relations across resources.
+
+Covers the backend side (Java ``Long`` columns + Liquibase
+``addForeignKeyConstraint``), the TypeScript side (``number`` in
+Create/Update/Response DTOs), the frontend form-rendering side
+(auto-promoted to a Combobox lookup, including self-references), and the
+``tree`` page's parent-field resolution via explicit ``reference`` fields.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from apps_generator.cli.generators.linking import find_java_root, find_resources_root
+from apps_generator.cli.generators.pages import generate_page_components
+from apps_generator.cli.generators.pages.base import detect_lookup
+from apps_generator.cli.generators.resources import (
+    generate_resource_scaffolding,
+    parse_resources,
+)
+from apps_generator.cli.generators.types import generate_resource_types
+from apps_generator.core.generator import generate
+from apps_generator.templates.registry import resolve_template
+
+
+# ── Backend: Java entity / DTOs ─────────────────────────────────────────────
+
+
+def _generate_with_resources(tmp_path: Path, resources_json: str):
+    template = resolve_template("api-domain")
+    result = generate(
+        template_dir=template.path,
+        output_dir=tmp_path / "gen",
+        cli_values={
+            "projectName": "test-svc",
+            "groupId": "com.test",
+            "basePackage": "com.test.app",
+            "features.oauth2": "false",
+        },
+        interactive=False,
+    )
+    java_root = find_java_root(result, "test-svc", "com.test.app")
+    res_root = find_resources_root(result, "test-svc")
+    resources = parse_resources(resources_json)
+    generate_resource_scaffolding(java_root, res_root, resources, "com.test.app", "test-svc")
+    return java_root, res_root
+
+
+def test_reference_field_generates_long_column_on_entity(tmp_path: Path) -> None:
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {"name": "department", "fields": [{"name": "name", "type": "string"}]},
+                {
+                    "name": "employee",
+                    "fields": [
+                        {"name": "name", "type": "string"},
+                        {"name": "departmentId", "type": "reference", "target": "department"},
+                    ],
+                },
+            ]
+        ),
+    )
+    entity = (java_root / "domain" / "model" / "Employee.java").read_text()
+    # Stored as a plain Long id — no @ManyToOne navigation object, keeps the
+    # DTO shape flat and lets the BFF stay boring.
+    assert "private Long departmentId;" in entity
+    # Getter/setter use the camelCase field name
+    assert "public Long getDepartmentId()" in entity
+    assert "public void setDepartmentId(Long departmentId)" in entity
+
+
+def test_reference_field_dto_uses_number_like_type(tmp_path: Path) -> None:
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {"name": "department", "fields": [{"name": "name", "type": "string"}]},
+                {
+                    "name": "employee",
+                    "fields": [
+                        {"name": "departmentId", "type": "reference", "target": "department"},
+                    ],
+                },
+            ]
+        ),
+    )
+    create = (java_root / "interfaces" / "rest" / "dto" / "CreateEmployeeRequest.java").read_text()
+    patch = (java_root / "interfaces" / "rest" / "dto" / "PatchEmployeeRequest.java").read_text()
+    resp = (java_root / "interfaces" / "rest" / "dto" / "EmployeeResponse.java").read_text()
+    for dto in (create, patch, resp):
+        assert "private Long departmentId;" in dto
+
+
+def test_reference_required_adds_not_null_on_dto(tmp_path: Path) -> None:
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {"name": "department", "fields": [{"name": "name", "type": "string"}]},
+                {
+                    "name": "employee",
+                    "fields": [
+                        {
+                            "name": "departmentId",
+                            "type": "reference",
+                            "target": "department",
+                            "required": True,
+                        },
+                    ],
+                },
+            ]
+        ),
+    )
+    create = (java_root / "interfaces" / "rest" / "dto" / "CreateEmployeeRequest.java").read_text()
+    # ``reference`` uses @NotNull, not @NotBlank (it's a Long, not a String)
+    assert "@NotNull" in create
+    # PATCH drops required-ness — reference field stays but @NotNull goes away
+    patch = (java_root / "interfaces" / "rest" / "dto" / "PatchEmployeeRequest.java").read_text()
+    assert "@NotNull" not in patch
+    assert "private Long departmentId;" in patch
+
+
+# ── Backend: Liquibase migration ────────────────────────────────────────────
+
+
+def test_reference_field_emits_fk_constraint_in_migration(tmp_path: Path) -> None:
+    _, res_root = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {"name": "department", "fields": [{"name": "name", "type": "string"}]},
+                {
+                    "name": "employee",
+                    "fields": [
+                        {"name": "departmentId", "type": "reference", "target": "department"},
+                    ],
+                },
+            ]
+        ),
+    )
+    # Employee is the second resource (seq 003) in the resources array
+    changelog = yaml.safe_load(
+        (res_root / "db" / "changelog" / "changes" / "003-create-employee.yaml").read_text()
+    )
+    changes = changelog["databaseChangeLog"][0]["changeSet"]["changes"]
+    fk_changes = [c for c in changes if "addForeignKeyConstraint" in c]
+    assert len(fk_changes) == 1
+    fk = fk_changes[0]["addForeignKeyConstraint"]
+    assert fk["baseTableName"] == "employees"
+    assert fk["baseColumnNames"] == "department_id"
+    assert fk["referencedTableName"] == "departments"
+    assert fk["referencedColumnNames"] == "id"
+    assert fk["constraintName"] == "fk_employees_department_id"
+
+
+def test_reference_field_column_is_bigint(tmp_path: Path) -> None:
+    _, res_root = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {"name": "department", "fields": [{"name": "name", "type": "string"}]},
+                {
+                    "name": "employee",
+                    "fields": [
+                        {"name": "departmentId", "type": "reference", "target": "department"},
+                    ],
+                },
+            ]
+        ),
+    )
+    changelog = yaml.safe_load(
+        (res_root / "db" / "changelog" / "changes" / "003-create-employee.yaml").read_text()
+    )
+    columns = changelog["databaseChangeLog"][0]["changeSet"]["changes"][0]["createTable"]["columns"]
+    dep_col = next(c["column"] for c in columns if c["column"]["name"] == "department_id")
+    assert dep_col["type"] == "BIGINT"
+
+
+def test_self_reference_fk_points_back_at_same_table(tmp_path: Path) -> None:
+    """Self-referencing resource (hierarchical) gets a FK back to its own id."""
+    _, res_root = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "department",
+                    "fields": [
+                        {"name": "name", "type": "string"},
+                        {"name": "parentId", "type": "reference", "target": "department"},
+                    ],
+                }
+            ]
+        ),
+    )
+    changelog = yaml.safe_load(
+        (res_root / "db" / "changelog" / "changes" / "002-create-department.yaml").read_text()
+    )
+    changes = changelog["databaseChangeLog"][0]["changeSet"]["changes"]
+    fk_changes = [c for c in changes if "addForeignKeyConstraint" in c]
+    assert len(fk_changes) == 1
+    fk = fk_changes[0]["addForeignKeyConstraint"]
+    assert fk["baseTableName"] == "departments"
+    assert fk["baseColumnNames"] == "parent_id"
+    assert fk["referencedTableName"] == "departments"
+
+
+# ── Backend: integration test ───────────────────────────────────────────────
+
+
+def test_required_reference_is_skipped_for_validation_test(tmp_path: Path) -> None:
+    """Reference fields can't be auto-populated (target row must exist), so the
+    "missing required field" validation test picks a simpler required field
+    or skips the test entirely. This keeps the generated test suite green.
+    """
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {"name": "department", "fields": [{"name": "name", "type": "string"}]},
+                {
+                    "name": "employee",
+                    "fields": [
+                        {"name": "name", "type": "string", "required": True},
+                        {
+                            "name": "departmentId",
+                            "type": "reference",
+                            "target": "department",
+                            "required": True,
+                        },
+                    ],
+                },
+            ]
+        ),
+    )
+    test = (
+        Path(str(java_root).replace("/main/java/", "/test/java/")) / "EmployeeIntegrationTest.java"
+    ).read_text()
+    # Validation test was generated — but drops ``name``, not ``departmentId``
+    assert "withMissingRequiredField_returns400" in test
+    # The missing-field JSON must still carry departmentId so the test isn't
+    # also tripping the FK-not-null — just not ``name``.
+    assert 'name' not in test.split("withMissingRequiredField_returns400")[1].split("}")[0]
+
+
+# ── TypeScript types ────────────────────────────────────────────────────────
+
+
+def test_reference_field_ts_type_is_number(tmp_path: Path) -> None:
+    src = tmp_path / "api-client" / "src"
+    src.mkdir(parents=True)
+    generate_resource_types(
+        src,
+        [
+            {
+                "name": "employee",
+                "fields": [
+                    {"name": "name", "type": "string", "required": True},
+                    {"name": "departmentId", "type": "reference", "target": "department"},
+                ],
+            }
+        ],
+    )
+    ts = (src / "resources" / "employee.ts").read_text()
+    # Response allows null (FK can be absent), Create/Update optional
+    assert "departmentId: number | null;" in ts
+    assert "departmentId?: number;" in ts
+
+
+# ── Lookup promotion ────────────────────────────────────────────────────────
+
+
+def test_detect_lookup_promotes_reference_with_valid_target() -> None:
+    field = {"name": "departmentId", "type": "reference", "target": "department"}
+    lk = detect_lookup(field, ["department", "employee"], current_resource="employee")
+    assert lk == {"resource": "department", "valueField": "id", "labelField": "name"}
+
+
+def test_detect_lookup_allows_self_reference_for_explicit_reference() -> None:
+    """Self-references are the whole point of tree-style configs — the
+    heuristic branch filters self out, but the explicit branch must not."""
+    field = {"name": "parentId", "type": "reference", "target": "department"}
+    lk = detect_lookup(field, ["department"], current_resource="department")
+    assert lk is not None
+    assert lk["resource"] == "department"
+
+
+def test_detect_lookup_returns_none_when_reference_target_is_unknown() -> None:
+    field = {"name": "xId", "type": "reference", "target": "ghost"}
+    assert detect_lookup(field, ["employee", "department"]) is None
+
+
+def test_detect_lookup_heuristic_still_skips_current_resource() -> None:
+    """Legacy heuristic path must not match a field on its own resource."""
+    field = {"name": "employeeName", "type": "string"}
+    assert detect_lookup(field, ["employee"], current_resource="employee") is None
+    # But when ``employee`` is a *different* resource, the match stands
+    assert (
+        detect_lookup(field, ["employee", "leave"], current_resource="leave") is not None
+    )
+
+
+# ── Form / edit emitter wiring ──────────────────────────────────────────────
+
+
+def test_form_renders_reference_as_combobox_with_uikit(tmp_path: Path) -> None:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "new",
+        "label": "New Employee",
+        "resource": "employee",
+        "type": "form",
+        "fields": [
+            {"name": "name", "type": "string", "required": True},
+            {"name": "departmentId", "type": "reference", "target": "department"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+        all_resources=["employee", "department"],
+    )
+    tsx = (project_root / "src" / "routes" / "NewPage.tsx").read_text()
+    assert "<Combobox" in tsx
+    # Fetches the target resource collection for options
+    assert 'api.get("/department"' in tsx
+    # departmentOptions is the variable name convention
+    assert "departmentOptions" in tsx
+    # Body casts the FK id to Number like other numeric fields
+    assert "departmentId: form.departmentId ? Number(form.departmentId) : undefined," in tsx
+
+
+def test_edit_renders_self_reference_as_combobox(tmp_path: Path) -> None:
+    """Edit page on a self-referencing resource must offer a parent picker —
+    the emitter used to pre-filter ``resource == current`` and blocked this."""
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "edit",
+        "label": "Edit Department",
+        "resource": "department",
+        "type": "edit",
+        "fields": [
+            {"name": "name", "type": "string", "required": True},
+            {"name": "parentId", "type": "reference", "target": "department"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+        all_resources=["department"],
+    )
+    tsx = (project_root / "src" / "routes" / "EditPage.tsx").read_text()
+    assert "<Combobox" in tsx
+    # Hydrates the FK id as a string (Combobox value is string)
+    assert 'parentId: data.parentId != null ? String(data.parentId) : "",' in tsx
+    # And casts back to Number on write
+    assert "parentId: form.parentId ? Number(form.parentId) : undefined," in tsx
+
+
+# ── Tree page: parent-field discovery ───────────────────────────────────────
+
+
+def test_tree_uses_explicit_reference_field_as_parent(tmp_path: Path) -> None:
+    """With an explicit ``reference`` self-ref, the tree uses *that* field —
+    not the legacy ``parentId`` literal. This unblocks configs that want
+    a different parent-pointer name (``managerId``, ``containerId``, ...)."""
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "org",
+        "label": "Org Chart",
+        "resource": "employee",
+        "type": "tree",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "managerId", "type": "reference", "target": "employee"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+    )
+    tsx = (project_root / "src" / "routes" / "OrgPage.tsx").read_text()
+    # The renamed parent pointer flows into the buildTree generic
+    assert "managerId?: string | number | null" in tsx
+    assert ".managerId" in tsx
+    # ``parentId`` must NOT leak through as a hardcoded literal
+    assert "parentId" not in tsx
+
+
+def test_tree_falls_back_to_parent_id_when_no_explicit_reference(tmp_path: Path) -> None:
+    """Configs without an explicit reference field keep working via the legacy
+    ``parentId`` convention."""
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "org",
+        "label": "Org Chart",
+        "resource": "department",
+        "type": "tree",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "parentId", "type": "long"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+    )
+    tsx = (project_root / "src" / "routes" / "OrgPage.tsx").read_text()
+    assert "parentId?: string | number | null" in tsx
+
+
+def test_tree_reference_to_other_resource_is_not_mistaken_for_parent(tmp_path: Path) -> None:
+    """A reference that points to a *different* resource is not a parent
+    pointer — the tree must keep looking for a self-ref or fall back to
+    the legacy ``parentId`` name."""
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    page = {
+        "path": "org",
+        "label": "Org Chart",
+        "resource": "employee",
+        "type": "tree",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "departmentId", "type": "reference", "target": "department"},
+        ],
+    }
+    generate_page_components(
+        project_root=project_root,
+        pages=[page],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+    )
+    tsx = (project_root / "src" / "routes" / "OrgPage.tsx").read_text()
+    # Fell back to the literal ``parentId`` — the cross-resource reference
+    # was correctly ignored as a parent candidate.
+    assert "parentId?: string | number | null" in tsx

--- a/tests/test_reference_field_type.py
+++ b/tests/test_reference_field_type.py
@@ -144,9 +144,7 @@ def test_reference_field_emits_fk_constraint_in_migration(tmp_path: Path) -> Non
         ),
     )
     # Employee is the second resource (seq 003) in the resources array
-    changelog = yaml.safe_load(
-        (res_root / "db" / "changelog" / "changes" / "003-create-employee.yaml").read_text()
-    )
+    changelog = yaml.safe_load((res_root / "db" / "changelog" / "changes" / "003-create-employee.yaml").read_text())
     changes = changelog["databaseChangeLog"][0]["changeSet"]["changes"]
     fk_changes = [c for c in changes if "addForeignKeyConstraint" in c]
     assert len(fk_changes) == 1
@@ -173,9 +171,7 @@ def test_reference_field_column_is_bigint(tmp_path: Path) -> None:
             ]
         ),
     )
-    changelog = yaml.safe_load(
-        (res_root / "db" / "changelog" / "changes" / "003-create-employee.yaml").read_text()
-    )
+    changelog = yaml.safe_load((res_root / "db" / "changelog" / "changes" / "003-create-employee.yaml").read_text())
     columns = changelog["databaseChangeLog"][0]["changeSet"]["changes"][0]["createTable"]["columns"]
     dep_col = next(c["column"] for c in columns if c["column"]["name"] == "department_id")
     assert dep_col["type"] == "BIGINT"
@@ -197,9 +193,7 @@ def test_self_reference_fk_points_back_at_same_table(tmp_path: Path) -> None:
             ]
         ),
     )
-    changelog = yaml.safe_load(
-        (res_root / "db" / "changelog" / "changes" / "002-create-department.yaml").read_text()
-    )
+    changelog = yaml.safe_load((res_root / "db" / "changelog" / "changes" / "002-create-department.yaml").read_text())
     changes = changelog["databaseChangeLog"][0]["changeSet"]["changes"]
     fk_changes = [c for c in changes if "addForeignKeyConstraint" in c]
     assert len(fk_changes) == 1
@@ -237,14 +231,12 @@ def test_required_reference_is_skipped_for_validation_test(tmp_path: Path) -> No
             ]
         ),
     )
-    test = (
-        Path(str(java_root).replace("/main/java/", "/test/java/")) / "EmployeeIntegrationTest.java"
-    ).read_text()
+    test = (Path(str(java_root).replace("/main/java/", "/test/java/")) / "EmployeeIntegrationTest.java").read_text()
     # Validation test was generated — but drops ``name``, not ``departmentId``
     assert "withMissingRequiredField_returns400" in test
     # The missing-field JSON must still carry departmentId so the test isn't
     # also tripping the FK-not-null — just not ``name``.
-    assert 'name' not in test.split("withMissingRequiredField_returns400")[1].split("}")[0]
+    assert "name" not in test.split("withMissingRequiredField_returns400")[1].split("}")[0]
 
 
 # ── TypeScript types ────────────────────────────────────────────────────────
@@ -299,9 +291,7 @@ def test_detect_lookup_heuristic_still_skips_current_resource() -> None:
     field = {"name": "employeeName", "type": "string"}
     assert detect_lookup(field, ["employee"], current_resource="employee") is None
     # But when ``employee`` is a *different* resource, the match stands
-    assert (
-        detect_lookup(field, ["employee", "leave"], current_resource="leave") is not None
-    )
+    assert detect_lookup(field, ["employee", "leave"], current_resource="leave") is not None
 
 
 # ── Form / edit emitter wiring ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- First-class `reference` field type: `{"name": "departmentId", "type": "reference", "target": "department"}`.
- Backend: `Long` column on the entity + `BIGINT` + `addForeignKeyConstraint` in Liquibase, flat DTOs (no `@ManyToOne`).
- Frontend: `form` / `edit` / `settings` auto-render a ui-kit **Combobox** against the target's list endpoint; self-references are now allowed so `tree` works without hand-rolling `parentId`.
- Cross-resource: put the target resource earlier in the `resources` array so its table exists when the FK is applied.

## Example

```json
[
  {"name": "department", "fields": [
    {"name": "name", "type": "string", "required": true},
    {"name": "parentId", "type": "reference", "target": "department"}
  ]},
  {"name": "employee", "fields": [
    {"name": "name", "type": "string", "required": true},
    {"name": "departmentId", "type": "reference", "target": "department", "required": true}
  ]}
]
```

## Test plan

- [x] `pytest tests/` — 245 green (228 existing + 17 new)
- [x] Generated `api-domain` with self + cross refs → FK constraints emit correctly, entities compile visually
- [x] Generated `frontend-app` with form/edit/tree on a self-referencing resource → `npm run build` (vite) succeeds
- [ ] Optional follow-up: tree-traversal endpoint (`GET /{resource}/{id}/children`) — deferred, noted in the roadmap
