### PR TITLE
docs: document `reference` field type

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ appgen generate api-domain -o ./product-service \
   -s projectName=product-service \
   -s groupId=com.example \
   -s basePackage=com.example.products \
-  -s 'resources=[{"name":"product","fields":[{"name":"name","type":"string","required":true,"maxLength":255},{"name":"price","type":"decimal","required":true,"min":0},{"name":"status","type":"enum","required":true,"values":["active","inactive","archived"]},{"name":"active","type":"boolean"}]}]' \
+  -s 'resources=[{"name":"category","fields":[{"name":"name","type":"string","required":true}]},{"name":"product","fields":[{"name":"name","type":"string","required":true,"maxLength":255},{"name":"price","type":"decimal","required":true,"min":0},{"name":"status","type":"enum","required":true,"values":["active","inactive","archived"]},{"name":"categoryId","type":"reference","target":"category"},{"name":"active","type":"boolean"}]}]' \
   --gateway ./gateway --api-client ./api-client
 
 # 6. Micro-frontend with data-aware pages (dashboard + list + grid + form + detail + edit)

--- a/docs/resources-and-crud.md
+++ b/docs/resources-and-crud.md
@@ -36,6 +36,7 @@ Each resource has a `name` (used for class names, table names, and URL paths) an
 | `date` | `LocalDate` | `DATE` | `string` | ISO 8601 date (e.g., `2025-01-15`) |
 | `datetime` | `LocalDateTime` | `TIMESTAMP` | `string` | ISO 8601 datetime (e.g., `2025-01-15T10:00:00`) |
 | `enum` | Java enum class | `VARCHAR` | union type | Predefined values. Use `"values": ["a", "b", "c"]`. Generates Java enum with `@Enumerated(EnumType.STRING)`, TypeScript union (`"a" \| "b" \| "c"`), and `<select>` dropdown in forms. |
+| `reference` | `Long` | `BIGINT` + FK | `number` | Foreign-key id pointing at another resource. Use `"target": "<resource>"`. Adds a Liquibase `addForeignKeyConstraint` to `{target}s(id)`; the `form` / `edit` pages auto-render a Combobox lookup against the target's list endpoint. Self-references are allowed — they power the `tree` page without needing a hand-rolled `parentId`. For cross-resource references, put the target resource earlier in the `resources` array so its table exists when the FK is applied. |
 
 ## Field Constraints
 


### PR DESCRIPTION
Follow-up to #26 — README and docs/resources-and-crud.md were missed when the `reference` field type shipped. Adds a row to the Field Types table and folds a `categoryId` reference into the README quick-start sample so the feature is discoverable from the main docs entry points.