### PR TITLE
feat: `stringArray` / `enumArray` field types + MultiSelect / TagInput ui-kit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,13 @@ Features: `database` (on), `oauth2` (on), `docker` (on), `kubernetes` (on), `cic
 }]
 ```
 
-**Field types:** string, text, integer, long, decimal, boolean, date, datetime, enum, **reference**.
+**Field types:** string, text, integer, long, decimal, boolean, date, datetime, enum, **reference**, **stringArray**, **enumArray**.
 
 **Enum fields** use a `values` array: `{"name": "status", "type": "enum", "values": ["active", "inactive"]}`. Generates Java enum class, `@Enumerated(EnumType.STRING)` on entity, TypeScript union type (`"active" | "inactive"`), and `<select>` dropdown in forms.
 
 **Reference fields** use a `target` pointing at another resource: `{"name": "departmentId", "type": "reference", "target": "department"}`. Generates a `Long` FK column on the entity (no `@ManyToOne` navigation — DTOs stay flat), a Liquibase `addForeignKeyConstraint` pointing at `{target}s(id)`, and a TypeScript `number` in the Create/Update/Response DTOs. Self-references are allowed (e.g. `department.parentId → department`) and power the `tree` page without the caller having to add `parentId` by hand. The `form` / `edit` pages auto-render a `reference` as a **Combobox** lookup against the target's list endpoint. Cross-resource references require the target resource to appear earlier in the `resources` array so its table exists when the FK is applied.
+
+**Array fields** — `stringArray` (free-form tag list) and `enumArray` (fixed option set): stored in a per-field `@ElementCollection` join table named `{parent_table}_{field}` with a CASCADE FK back to the parent. Entity uses `List<String>` / `List<EnumName>` with a `new ArrayList<>()` initializer so callers never hit a null collection. DTOs round-trip as plain `List<...>`; TypeScript types are `string[]` / `(union)[]`. The `form` / `edit` pages render **`TagInput`** for `stringArray` (chip-style Enter-to-add) and **`MultiSelect`** for `enumArray` (typeahead with selected chips) when `--uikit` is linked; plain-HTML falls back to a comma-separated `<input>` for `stringArray` and a `<select multiple>` for `enumArray`.
 
 **Constraints:** required, unique, maxLength, minLength, min, max, pattern.
 
@@ -248,6 +250,8 @@ src/apps_generator/
 | datetime | LocalDateTime | TIMESTAMP | string |
 | enum | Java enum class | VARCHAR | union type (e.g. `"a" \| "b"`) |
 | reference | Long | BIGINT + FK | number |
+| stringArray | `List<String>` | join table + FK | `string[]` |
+| enumArray | `List<EnumName>` | join table + FK | `(union)[]` |
 
 ## CSS theme
 

--- a/docs/resources-and-crud.md
+++ b/docs/resources-and-crud.md
@@ -37,6 +37,8 @@ Each resource has a `name` (used for class names, table names, and URL paths) an
 | `datetime` | `LocalDateTime` | `TIMESTAMP` | `string` | ISO 8601 datetime (e.g., `2025-01-15T10:00:00`) |
 | `enum` | Java enum class | `VARCHAR` | union type | Predefined values. Use `"values": ["a", "b", "c"]`. Generates Java enum with `@Enumerated(EnumType.STRING)`, TypeScript union (`"a" \| "b" \| "c"`), and `<select>` dropdown in forms. |
 | `reference` | `Long` | `BIGINT` + FK | `number` | Foreign-key id pointing at another resource. Use `"target": "<resource>"`. Adds a Liquibase `addForeignKeyConstraint` to `{target}s(id)`; the `form` / `edit` pages auto-render a Combobox lookup against the target's list endpoint. Self-references are allowed — they power the `tree` page without needing a hand-rolled `parentId`. For cross-resource references, put the target resource earlier in the `resources` array so its table exists when the FK is applied. |
+| `stringArray` | `List<String>` | join table + FK | `string[]` | Free-form tag list. Stored via `@ElementCollection` in a `{table}_{field}` join table with a CASCADE FK back to the parent. Forms render a **TagInput** (with `--uikit`) or a comma-separated `<input>` (fallback). |
+| `enumArray` | `List<EnumName>` | join table + FK | `(union)[]` | Multi-select over a fixed option set. Use `"values": ["a", "b"]`. Same join-table shape as `stringArray`; entity field uses `@Enumerated(EnumType.STRING)` per element. Forms render a **MultiSelect** typeahead (with `--uikit`) or a native `<select multiple>` (fallback). |
 
 ## Field Constraints
 

--- a/src/apps_generator/cli/generators/migrations.py
+++ b/src/apps_generator/cli/generators/migrations.py
@@ -9,7 +9,7 @@ import yaml
 from apps_generator.utils.console import console
 from apps_generator.utils.naming import snake_case
 
-from apps_generator.cli.generators.resources import SQL_TYPES
+from apps_generator.cli.generators.resources import ARRAY_TYPES, SQL_TYPES
 
 
 def generate_migration(res_root: Path, entity: str, table: str, fields: list[dict], seq: int, name: str) -> None:
@@ -28,6 +28,10 @@ def generate_migration(res_root: Path, entity: str, table: str, fields: list[dic
 
     for f in fields:
         ft = f.get("type", "string")
+        # Array fields don't get a column on the parent table — their values
+        # live in a separate join table emitted below via @ElementCollection.
+        if ft in ARRAY_TYPES:
+            continue
         sql_type = SQL_TYPES.get(ft, "VARCHAR(255)")
         if ft == "string":
             max_len = f.get("maxLength", 255)
@@ -107,6 +111,69 @@ def generate_migration(res_root: Path, entity: str, table: str, fields: list[dic
                     "referencedTableName": target_table,
                     "referencedColumnNames": "id",
                     "constraintName": f"fk_{table}_{col_name}",
+                }
+            }
+        )
+
+    # Join tables for @ElementCollection array fields. One table per array:
+    # ``{parent_table}_{field}`` holding one row per list element, with a FK
+    # back to the parent. Hibernate ties the schema to the annotation via
+    # ``@CollectionTable(name=..., joinColumns=...)`` — the names here must
+    # match the entity's annotation exactly or Liquibase schema validation
+    # fails at startup.
+    parent_snake = snake_case(entity)
+    join_col = f"{parent_snake}_id"
+    for f in fields:
+        if f.get("type") not in ARRAY_TYPES:
+            continue
+        field_snake = snake_case(f["name"])
+        join_table = f"{table}_{field_snake}"
+        if f.get("type") == "enumArray":
+            element_len = max((len(v) for v in f.get("values", [""])), default=50)
+            element_type = f"VARCHAR({element_len})"
+        else:
+            element_type = f"VARCHAR({f.get('maxLength', 255)})"
+        changeset["changes"].append(
+            {
+                "createTable": {
+                    "tableName": join_table,
+                    "columns": [
+                        {
+                            "column": {
+                                "name": join_col,
+                                "type": "BIGINT",
+                                "constraints": {"nullable": False},
+                            }
+                        },
+                        {
+                            "column": {
+                                "name": field_snake,
+                                "type": element_type,
+                                "constraints": {"nullable": False},
+                            }
+                        },
+                    ],
+                }
+            }
+        )
+        changeset["changes"].append(
+            {
+                "addForeignKeyConstraint": {
+                    "baseTableName": join_table,
+                    "baseColumnNames": join_col,
+                    "referencedTableName": table,
+                    "referencedColumnNames": "id",
+                    "constraintName": f"fk_{join_table}_{join_col}",
+                    "onDelete": "CASCADE",
+                }
+            }
+        )
+        changeset["changes"].append(
+            {
+                "createIndex": {
+                    "tableName": join_table,
+                    "indexName": f"idx_{join_table}_{join_col}",
+                    "columns": [{"column": {"name": join_col}}],
                 }
             }
         )

--- a/src/apps_generator/cli/generators/pages/edit_type.py
+++ b/src/apps_generator/cli/generators/pages/edit_type.py
@@ -49,6 +49,17 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
 
     # ui-kit imports — edit needs Form primitives + AlertDialog for the
     # destructive confirm flow. AlertDialog is a Phase 0 addition.
+    # TagInput / MultiSelect join the import line only when the page has
+    # the matching array field type so unused components don't leak into
+    # the tree-shake output.
+    has_string_array = any(f.get("type") == "stringArray" for f in fields)
+    has_enum_array = any(f.get("type") == "enumArray" for f in fields)
+    array_extra = ""
+    if has_string_array:
+        array_extra += ", TagInput"
+    if has_enum_array:
+        array_extra += ", MultiSelect"
+
     if ui:
         ui_import = (
             f"import {{ Button, Input, Label, Textarea, Checkbox, "
@@ -56,7 +67,7 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
             f"AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, "
             f"AlertDialogFooter, AlertDialogTitle, AlertDialogDescription, "
             f"AlertDialogAction, AlertDialogCancel, "
-            f'DatePicker, Combobox }} from "{ui}";\n'
+            f'DatePicker, Combobox{array_extra} }} from "{ui}";\n'
         )
     else:
         ui_import = ""
@@ -68,6 +79,8 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
         fname = camel_case(f["name"])
         if ft == "boolean":
             defaults[fname] = "false"
+        elif ft in ("stringArray", "enumArray"):
+            defaults[fname] = "[] as string[]"
         else:
             defaults[fname] = '""'
     state_init = ", ".join(f"{k}: {v}" for k, v in defaults.items())
@@ -75,7 +88,8 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
     # State hydration — map each fetched field into the form. Numbers come
     # back as numbers from the API but the form state expects strings.
     # Reference fields are stringified for the same reason — the Combobox
-    # option values are strings.
+    # option values are strings. Array fields keep their ``[]`` fallback
+    # so the controlled TagInput/MultiSelect never sees ``undefined``.
     hydrate_lines: list[str] = []
     for f in fields:
         ft = f.get("type", "string")
@@ -87,6 +101,8 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
         elif ft == "datetime":
             # HTML datetime-local wants YYYY-MM-DDTHH:mm (no TZ) — trim any zone.
             hydrate_lines.append(f'          {fname}: data.{fname} ? String(data.{fname}).slice(0, 16) : "",')
+        elif ft in ("stringArray", "enumArray"):
+            hydrate_lines.append(f"          {fname}: data.{fname} ?? [],")
         else:
             hydrate_lines.append(f'          {fname}: data.{fname} ?? "",')
     hydrate_str = "\n".join(hydrate_lines)
@@ -186,6 +202,32 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
                     f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
                     f"        </div>"
                 )
+            elif ft == "stringArray":
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f"          <TagInput\n"
+                    f'            id="{fname}"\n'
+                    f"            value={{form.{fname}}}\n"
+                    f"            onChange={{(v) => setForm(f => ({{...f, {fname}: v}}))}}\n"
+                    f'            placeholder="Add and press Enter..."\n'
+                    f"          />\n"
+                    f"        </div>"
+                )
+            elif ft == "enumArray" and f.get("values"):
+                ms_options = ", ".join(f'{{ value: "{v}", label: "{title_case(v)}" }}' for v in f["values"])
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f"          <MultiSelect\n"
+                    f'            id="{fname}"\n'
+                    f"            options={{[{ms_options}]}}\n"
+                    f"            value={{form.{fname}}}\n"
+                    f"            onChange={{(v) => setForm(f => ({{...f, {fname}: v}}))}}\n"
+                    f'            placeholder="Select {flabel}..."\n'
+                    f"          />\n"
+                    f"        </div>"
+                )
             elif ft == "enum" and f.get("values"):
                 options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
                 inputs.append(
@@ -242,6 +284,26 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
                     f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}</label>\n'
                     f"        </div>"
                 )
+            elif ft == "stringArray":
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star} (comma-separated)</label>\n'
+                    f'          <input id="{fname}" type="text" className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"\n'
+                    f"            value={{form.{fname}.join(', ')}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value.split(',').map((s: string) => s.trim()).filter(Boolean)}}))}}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "enumArray" and f.get("values"):
+                multi_options = "".join(
+                    f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"]
+                )
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f'          <select multiple id="{fname}" className="mt-1 flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-24"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: Array.from(e.target.selectedOptions, (o: HTMLOptionElement) => o.value)}}))}}>{multi_options}\n"
+                    f"          </select>\n"
+                    f"        </div>"
+                )
             elif ft == "enum" and f.get("values"):
                 options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
                 inputs.append(
@@ -276,12 +338,15 @@ def emit_edit(page: dict, ctx: PageContext) -> None:
 
     # Body of the PUT — cast numeric fields back to numbers. Reference
     # fields are FK ids (backend ``Long``) so they share the Number cast.
+    # Arrays pass through as-is (``string[]`` on both sides of the wire).
     body_fields: list[str] = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
         if ft in ("integer", "long", "decimal", "reference"):
             body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
+        elif ft in ("stringArray", "enumArray"):
+            body_fields.append(f"        {fname}: form.{fname},")
         elif ft == "boolean":
             body_fields.append(f"        {fname}: form.{fname},")
         else:

--- a/src/apps_generator/cli/generators/pages/form_type.py
+++ b/src/apps_generator/cli/generators/pages/form_type.py
@@ -31,17 +31,29 @@ def emit_form(page: dict, ctx: PageContext) -> None:
     _api_pkg = ctx.api_client_name or "my-api-client"
     ui = ctx.uikit_name
 
-    # ui-kit imports
+    # ui-kit imports — MultiSelect/TagInput are pulled in only when the form
+    # has a matching array field, but keeping them on the main import line
+    # keeps the emitted JSX readable without conditional branching.
+    has_string_array = any(f.get("type") == "stringArray" for f in fields)
+    has_enum_array = any(f.get("type") == "enumArray" for f in fields)
+    array_extra = ""
+    if has_string_array:
+        array_extra += ", TagInput"
+    if has_enum_array:
+        array_extra += ", MultiSelect"
+
     if ui:
         ui_import = (
             f"import {{ Button, Input, Label, Textarea, Checkbox, "
             f"Card, CardContent, CardHeader, CardTitle, Alert, AlertDescription, "
-            f'DatePicker, Combobox }} from "{ui}";\n'
+            f'DatePicker, Combobox{array_extra} }} from "{ui}";\n'
         )
     else:
         ui_import = ""
 
-    # Build form state defaults
+    # Build form state defaults. Arrays default to ``[]`` so the TagInput /
+    # MultiSelect values never go through the ``undefined`` → uncontrolled
+    # → controlled React warning path.
     defaults = {}
     for f in fields:
         ft = f.get("type", "string")
@@ -50,6 +62,8 @@ def emit_form(page: dict, ctx: PageContext) -> None:
             defaults[fname] = '""'
         elif ft == "boolean":
             defaults[fname] = "false"
+        elif ft in ("stringArray", "enumArray"):
+            defaults[fname] = "[] as string[]"
         else:
             defaults[fname] = '""'
 
@@ -155,6 +169,34 @@ def emit_form(page: dict, ctx: PageContext) -> None:
                     f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value}}))}}{'required ' if required else ''}/>\n"
                     f"        </div>"
                 )
+            elif ft == "stringArray":
+                # Free-form chip input — any string the user types becomes a tag.
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f"          <TagInput\n"
+                    f'            id="{fname}"\n'
+                    f"            value={{form.{fname}}}\n"
+                    f"            onChange={{(v) => setForm(f => ({{...f, {fname}: v}}))}}\n"
+                    f'            placeholder="Add and press Enter..."\n'
+                    f"          />\n"
+                    f"        </div>"
+                )
+            elif ft == "enumArray" and f.get("values"):
+                # Fixed option set — MultiSelect (Command + Popover + Badge).
+                ms_options = ", ".join(f'{{ value: "{v}", label: "{title_case(v)}" }}' for v in f["values"])
+                inputs.append(
+                    f'        <div className="space-y-2">\n'
+                    f'          <Label htmlFor="{fname}">{flabel}{req_star}</Label>\n'
+                    f"          <MultiSelect\n"
+                    f'            id="{fname}"\n'
+                    f"            options={{[{ms_options}]}}\n"
+                    f"            value={{form.{fname}}}\n"
+                    f"            onChange={{(v) => setForm(f => ({{...f, {fname}: v}}))}}\n"
+                    f'            placeholder="Select {flabel}..."\n'
+                    f"          />\n"
+                    f"        </div>"
+                )
             elif ft == "enum" and f.get("values"):
                 options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
                 inputs.append(
@@ -211,6 +253,28 @@ def emit_form(page: dict, ctx: PageContext) -> None:
                     f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}</label>\n'
                     f"        </div>"
                 )
+            elif ft == "stringArray":
+                # Plain-HTML fallback — no chip widget; a comma-separated
+                # ``<input>`` gets the user across the finish line.
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star} (comma-separated)</label>\n'
+                    f'          <input id="{fname}" type="text" className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"\n'
+                    f"            value={{form.{fname}.join(', ')}} onChange={{e => setForm(f => ({{...f, {fname}: e.target.value.split(',').map((s: string) => s.trim()).filter(Boolean)}}))}}/>\n"
+                    f"        </div>"
+                )
+            elif ft == "enumArray" and f.get("values"):
+                multi_options = "".join(
+                    f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"]
+                )
+                inputs.append(
+                    f"        <div>\n"
+                    f'          <label className="text-sm font-medium" htmlFor="{fname}">{flabel}{req_star}</label>\n'
+                    f'          <select multiple id="{fname}" className="mt-1 flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm min-h-24"\n'
+                    f"            value={{form.{fname}}} onChange={{e => setForm(f => ({{...f, {fname}: Array.from(e.target.selectedOptions, (o: HTMLOptionElement) => o.value)}}))}}>{multi_options}\n"
+                    f"          </select>\n"
+                    f"        </div>"
+                )
             elif ft == "enum" and f.get("values"):
                 options = "".join(f'\n              <option value="{v}">{title_case(v)}</option>' for v in f["values"])
                 inputs.append(
@@ -245,13 +309,16 @@ def emit_form(page: dict, ctx: PageContext) -> None:
 
     # Build submission body (cast number fields). Reference fields are FK ids
     # stored as ``Long`` on the backend, so they need the same Number cast as
-    # any other numeric type.
+    # any other numeric type. Arrays pass through as-is — they're already
+    # a ``string[]`` in form state and the BE expects a JSON array.
     body_fields = []
     for f in fields:
         ft = f.get("type", "string")
         fname = camel_case(f["name"])
         if ft in ("integer", "long", "decimal", "reference"):
             body_fields.append(f"        {fname}: form.{fname} ? Number(form.{fname}) : undefined,")
+        elif ft in ("stringArray", "enumArray"):
+            body_fields.append(f"        {fname}: form.{fname},")
         elif ft == "boolean":
             body_fields.append(f"        {fname}: form.{fname},")
         else:

--- a/src/apps_generator/cli/generators/resources.py
+++ b/src/apps_generator/cli/generators/resources.py
@@ -22,6 +22,8 @@ JAVA_TYPES = {
     "datetime": "LocalDateTime",
     "enum": "__ENUM__",  # placeholder — replaced by generated enum class name
     "reference": "Long",  # FK id pointing at another resource's id column
+    "stringArray": "List<String>",
+    "enumArray": "List<__ENUM__>",  # element type resolved to the generated enum class
 }
 
 SQL_TYPES = {
@@ -35,6 +37,11 @@ SQL_TYPES = {
     "datetime": "TIMESTAMP",
     "enum": "VARCHAR({maxLength})",
     "reference": "BIGINT",
+    # Array types are stored in a join table, not a column on the parent table
+    # — the SQL_TYPES entry here isn't used by the column loop; the join-table
+    # migration synthesises its own ``VARCHAR(N)`` column for the element.
+    "stringArray": "VARCHAR(255)",
+    "enumArray": "VARCHAR(255)",
 }
 
 TS_TYPES = {
@@ -48,13 +55,22 @@ TS_TYPES = {
     "datetime": "string",
     "enum": "__ENUM__",  # placeholder — replaced by union type
     "reference": "number",
+    "stringArray": "string[]",
+    "enumArray": "__ENUM__",  # placeholder — replaced by `(union)[]`
 }
 
 JAVA_IMPORTS = {
     "decimal": "java.math.BigDecimal",
     "date": "java.time.LocalDate",
     "datetime": "java.time.LocalDateTime",
+    "stringArray": "java.util.List",
+    "enumArray": "java.util.List",
 }
+
+# Field types that map onto a ``@ElementCollection`` join table rather than
+# a plain column on the parent entity. Kept as a tuple so membership checks
+# stay O(1) and the emitter code reads cleanly.
+ARRAY_TYPES = ("stringArray", "enumArray")
 
 
 # -- Parsing ------------------------------------------------------------------
@@ -98,9 +114,11 @@ def generate_resource_scaffolding(
         label = f"{entity_name} (singleton)" if is_singleton else entity_name
         console.print(f"  Generating resource: [bold]{label}[/bold]")
 
-        # Generate enum classes first (needed by entity)
+        # Generate enum classes first (needed by entity). Both ``enum`` and
+        # ``enumArray`` use the same generated class; the only difference is
+        # that arrays wrap it in ``List<...>`` at the use site.
         for f in fields:
-            if f.get("type") == "enum" and f.get("values"):
+            if f.get("type") in ("enum", "enumArray") and f.get("values"):
                 _gen_enum_class(java_root, base_package, entity_name, f)
 
         _gen_entity(java_root, base_package, entity_name, table_name, fields)
@@ -124,27 +142,35 @@ def generate_resource_scaffolding(
             _gen_integration_test(test_root, base_package, entity_name, name, fields)
 
 
-def _collect_imports(fields: list[dict]) -> list[str]:
-    """Collect extra Java imports needed for field types (non-enum)."""
+def _collect_imports(fields: list[dict], *, include_array_init: bool = False) -> list[str]:
+    """Collect extra Java imports needed for field types (non-enum).
+
+    ``include_array_init=True`` additionally pulls in ``java.util.ArrayList``
+    for the entity's ``new ArrayList<>()`` initialiser. DTOs don't need it
+    because they don't initialise array fields.
+    """
     imports = set()
     for f in fields:
         ft = f.get("type", "string")
         if ft in JAVA_IMPORTS:
             imports.add(JAVA_IMPORTS[ft])
+    if include_array_init and any(f.get("type") in ARRAY_TYPES for f in fields):
+        imports.add("java.util.ArrayList")
     return sorted(imports)
 
 
 def _collect_enum_imports(pkg: str, fields: list[dict]) -> list[str]:
-    """Return fully-qualified imports for every enum field's generated class.
+    """Return fully-qualified imports for every enum / enumArray field's generated class.
 
     Enum classes live under ``{pkg}.domain.model`` (see :func:`_gen_enum_class`).
     DTOs under ``{pkg}.interfaces.rest.dto`` need explicit imports to resolve
-    them at compile time — without this, any resource with an enum field
-    produced DTOs that would not compile.
+    them at compile time — without this, any resource with an enum (or
+    ``enumArray``) field produced DTOs that would not compile.
     """
     imports: set[str] = set()
     for f in fields:
-        if f.get("type") == "enum" and f.get("values"):
+        ft = f.get("type")
+        if ft in ("enum", "enumArray") and f.get("values"):
             enum_name = pascal_case(f["name"])
             imports.add(f"{pkg}.domain.model.{enum_name}")
     return sorted(imports)
@@ -167,30 +193,69 @@ def _gen_enum_class(java_root: Path, pkg: str, entity: str, field: dict) -> str:
 
 
 def _java_type_for_field(f: dict) -> str:
-    """Get Java type for a field, handling enum specially."""
+    """Get Java type for a field, handling enum and array specials."""
     ft = f.get("type", "string")
     if ft == "enum":
         return pascal_case(f["name"])
+    if ft == "stringArray":
+        return "List<String>"
+    if ft == "enumArray":
+        # The element enum class is generated under ``{pkg}.domain.model`` via
+        # ``_gen_enum_class`` — its name derives from the field name, same
+        # convention as plain ``enum`` fields.
+        return f"List<{pascal_case(f['name'])}>"
     return JAVA_TYPES.get(ft, "String")
 
 
 def _ts_type_for_field(f: dict) -> str:
-    """Get TypeScript type for a field, handling enum specially."""
+    """Get TypeScript type for a field, handling enum and array specials."""
     ft = f.get("type", "string")
     if ft == "enum":
         values = f.get("values", [])
         if values:
             return " | ".join(f'"{v}"' for v in values)
         return "string"
+    if ft == "stringArray":
+        return "string[]"
+    if ft == "enumArray":
+        values = f.get("values", [])
+        if values:
+            # Parenthesise the union so the ``[]`` binds to the whole thing,
+            # not just the last member — ``"a" | "b"[]`` would be
+            # ``"a" | ("b"[])`` otherwise.
+            return "(" + " | ".join(f'"{v}"' for v in values) + ")[]"
+        return "string[]"
     return TS_TYPES.get(ft, "string")
 
 
-def _java_field(f: dict, with_validation: bool = False, with_required: bool = True) -> str:
+def _array_collection_table(entity: str, f: dict) -> str:
+    """Return the join-table name for a ``stringArray`` / ``enumArray`` field.
+
+    The name is ``{plural_table}_{field}`` where ``plural_table`` matches the
+    entity's main table name (``{snake}s``) and ``{field}`` is the snake-case
+    field name. This matches Hibernate's default but we spell it explicitly
+    so the Liquibase migration and the ``@CollectionTable`` annotation agree.
+    """
+    return f"{snake_case(entity)}s_{snake_case(f['name'])}"
+
+
+def _java_field(
+    f: dict,
+    with_validation: bool = False,
+    with_required: bool = True,
+    *,
+    entity: str | None = None,
+) -> str:
     """Generate a Java field declaration with optional validation annotations.
 
     ``with_required=False`` drops ``@NotBlank`` / ``@NotNull`` but keeps every
     other constraint (``@Size``, ``@Min``, ``@Max``, ``@Pattern``) — those only
     fire when the field is present, which is exactly what PATCH bodies need.
+
+    For ``stringArray`` / ``enumArray`` fields the entity-side rendering
+    (``with_validation=False``) switches to ``@ElementCollection`` +
+    ``@CollectionTable`` and a ``new ArrayList<>()`` initialiser; the DTO
+    side stays a plain ``List<...>`` declaration.
     """
     ft = f.get("type", "string")
     java_type = _java_type_for_field(f)
@@ -203,9 +268,12 @@ def _java_field(f: dict, with_validation: bool = False, with_required: bool = Tr
     max_val = f.get("max")
     pattern = f.get("pattern")
 
-    lines = []
+    lines: list[str] = []
 
     if with_validation:
+        # Arrays use ``@NotNull`` + ``@Size`` (a List is never "blank") — the
+        # conventional ``@NotEmpty`` would also work but @NotNull + required
+        # check keeps the annotation surface consistent with other types.
         if with_required and required and ft in ("string", "text"):
             lines.append("    @NotBlank")
         elif with_required and required:
@@ -224,24 +292,43 @@ def _java_field(f: dict, with_validation: bool = False, with_required: bool = Tr
         if pattern:
             lines.append(f'    @Pattern(regexp = "{pattern}")')
 
-    # Column annotation for entity
-    col_parts = []
-    if required and not with_validation:
-        col_parts.append("nullable = false")
-    if unique and not with_validation:
-        col_parts.append("unique = true")
-    if ft == "decimal" and not with_validation:
-        col_parts.append("precision = 19")
-        col_parts.append("scale = 4")
-    if max_len and not with_validation:
-        col_parts.append(f"length = {max_len}")
+    # Entity-only annotations (skipped when emitting DTO fields).
+    if not with_validation:
+        if ft in ARRAY_TYPES:
+            # ``@ElementCollection`` persists each list element as its own row
+            # in a child table; ``@CollectionTable`` pins the name + FK so the
+            # Liquibase migration and the Hibernate mapping don't drift apart.
+            table_name = _array_collection_table(entity or "", f)
+            join_col = f"{snake_case(entity or '')}_id"
+            value_col = snake_case(f["name"])
+            lines.append("    @ElementCollection(fetch = FetchType.EAGER)")
+            lines.append(f'    @CollectionTable(name = "{table_name}", joinColumns = @JoinColumn(name = "{join_col}"))')
+            lines.append(f'    @Column(name = "{value_col}")')
+            if ft == "enumArray":
+                lines.append("    @Enumerated(EnumType.STRING)")
+            # Default to an empty list so callers never hit a null collection
+            # when building an entity imperatively (e.g. in the controller's
+            # request→entity mapping).
+            lines.append(f"    private {java_type} {name} = new ArrayList<>();")
+            return "\n".join(lines)
 
-    if col_parts and not with_validation:
-        lines.append(f"    @Column({', '.join(col_parts)})")
+        # Column annotation for scalar entity fields
+        col_parts = []
+        if required:
+            col_parts.append("nullable = false")
+        if unique:
+            col_parts.append("unique = true")
+        if ft == "decimal":
+            col_parts.append("precision = 19")
+            col_parts.append("scale = 4")
+        if max_len:
+            col_parts.append(f"length = {max_len}")
+        if col_parts:
+            lines.append(f"    @Column({', '.join(col_parts)})")
 
-    # Enum annotation for entity
-    if ft == "enum" and not with_validation:
-        lines.append("    @Enumerated(EnumType.STRING)")
+        # Enum annotation for scalar entity fields
+        if ft == "enum":
+            lines.append("    @Enumerated(EnumType.STRING)")
 
     lines.append(f"    private {java_type} {name};")
     return "\n".join(lines)
@@ -253,12 +340,14 @@ def _gen_entity(java_root: Path, pkg: str, entity: str, table: str, fields: list
     if dest.exists():
         return
 
-    extra_imports = _collect_imports(fields)
+    # ``include_array_init=True`` pulls in ``java.util.ArrayList`` for the
+    # default ``= new ArrayList<>()`` initialiser on array fields.
+    extra_imports = _collect_imports(fields, include_array_init=True)
     import_lines = "\n".join(f"import {i};" for i in extra_imports)
     if import_lines:
         import_lines = "\n" + import_lines
 
-    field_lines = "\n\n".join(_java_field(f) for f in fields)
+    field_lines = "\n\n".join(_java_field(f, entity=entity) for f in fields)
 
     # Getters and setters (only for user-defined fields — id/tenantId/timestamps come from base)
     accessors = []
@@ -889,6 +978,16 @@ def _gen_integration_test(test_root: Path, pkg: str, entity: str, name: str, fie
             json_fields.append(f'\\"{fname}\\": \\"2025-01-15\\"')
         elif ft == "datetime":
             json_fields.append(f'\\"{fname}\\": \\"2025-01-15T10:00:00\\"')
+        elif ft == "stringArray":
+            # Empty list keeps @NotNull happy without inventing values; the
+            # test still exercises CRUD round-trip for the parent row.
+            json_fields.append(f'\\"{fname}\\": []')
+        elif ft == "enumArray":
+            values = f.get("values", [])
+            if values:
+                json_fields.append(f'\\"{fname}\\": [\\"{values[0]}\\"]')
+            else:
+                json_fields.append(f'\\"{fname}\\": []')
     json_body = "{ " + ", ".join(json_fields) + " }"
 
     # Find a required string field for update test

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/multi-select.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/multi-select.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./command";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface MultiSelectProps {
+  options: MultiSelectOption[];
+  value?: string[];
+  onChange?: (value: string[]) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  name?: string;
+}
+
+/**
+ * Multi-selection typeahead built from Command + Popover + Badge.
+ *
+ * Mirrors the Combobox API but keeps ``value`` as a ``string[]``. Clicking
+ * an option toggles its membership; already-selected values render as
+ * removable badges inside the trigger so the current selection is always
+ * visible without opening the dropdown. Suitable for short-to-medium
+ * option lists (e.g. enum-backed ``enumArray`` form fields in generated
+ * pages).
+ */
+const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>(
+  (
+    {
+      options,
+      value = [],
+      onChange,
+      placeholder = "Select...",
+      searchPlaceholder = "Search...",
+      emptyText = "No results.",
+      disabled,
+      className,
+      id,
+      name,
+    },
+    ref,
+  ) => {
+    const [open, setOpen] = React.useState(false);
+    const selected = new Set(value);
+
+    const toggle = (v: string) => {
+      const next = new Set(selected);
+      if (next.has(v)) next.delete(v);
+      else next.add(v);
+      onChange?.(Array.from(next));
+    };
+
+    const remove = (v: string) => {
+      onChange?.(value.filter((x) => x !== v));
+    };
+
+    const selectedOptions = options.filter((o) => selected.has(o.value));
+
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={ref}
+            id={id}
+            name={name}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className={cn(
+              "h-auto min-h-10 w-full justify-between font-normal flex-wrap py-1.5",
+              className,
+            )}
+          >
+            <div className="flex flex-wrap gap-1 items-center">
+              {selectedOptions.length === 0 ? (
+                <span className="text-muted-foreground">{placeholder}</span>
+              ) : (
+                selectedOptions.map((opt) => (
+                  <Badge key={opt.value} variant="secondary" className="gap-1">
+                    {opt.label}
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Remove ${opt.label}`}
+                      className="rounded-sm hover:bg-muted-foreground/20 focus:outline-none"
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          remove(opt.value);
+                        }
+                      }}
+                      onMouseDown={(e) => {
+                        // mouseDown fires before PopoverTrigger's click — stop
+                        // the event so we don't toggle the dropdown open/close
+                        // as a side effect of removing a badge.
+                        e.preventDefault();
+                        e.stopPropagation();
+                        remove(opt.value);
+                      }}
+                    >
+                      <X className="h-3 w-3" />
+                    </span>
+                  </Badge>
+                ))
+              )}
+            </div>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+          <Command>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyText}</CommandEmpty>
+              <CommandGroup>
+                {options.map((opt) => (
+                  <CommandItem
+                    key={opt.value}
+                    value={opt.label}
+                    disabled={opt.disabled}
+                    onSelect={() => toggle(opt.value)}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        selected.has(opt.value) ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {opt.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
+MultiSelect.displayName = "MultiSelect";
+
+export { MultiSelect };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/tag-input.tsx
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/components/ui/tag-input.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "./badge";
+
+export interface TagInputProps {
+  value?: string[];
+  onChange?: (value: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  name?: string;
+  /** Separator keys that commit the current input as a new tag. Defaults to Enter + comma. */
+  separators?: string[];
+  /** Optional: drop duplicates silently. Default ``true``. */
+  dedupe?: boolean;
+}
+
+/**
+ * Free-form chip input for building a list of strings.
+ *
+ * Typing + Enter (or comma) commits the current draft as a new Badge chip;
+ * Backspace on an empty input removes the trailing chip. Suitable for
+ * ad-hoc tag / keyword lists (the ``stringArray`` form-field type in
+ * generated pages). For a fixed option set, reach for ``MultiSelect``
+ * instead.
+ */
+const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
+  (
+    {
+      value = [],
+      onChange,
+      placeholder = "Add and press Enter...",
+      disabled,
+      className,
+      id,
+      name,
+      separators = ["Enter", ","],
+      dedupe = true,
+    },
+    ref,
+  ) => {
+    const [draft, setDraft] = React.useState("");
+
+    const addTag = (raw: string) => {
+      const tag = raw.trim();
+      if (!tag) return;
+      if (dedupe && value.includes(tag)) {
+        setDraft("");
+        return;
+      }
+      onChange?.([...value, tag]);
+      setDraft("");
+    };
+
+    const removeTag = (index: number) => {
+      onChange?.(value.filter((_, i) => i !== index));
+    };
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (separators.includes(e.key)) {
+        e.preventDefault();
+        addTag(draft);
+      } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
+        // Backspace on empty input peels off the last tag — matches the
+        // native chip-input convention.
+        e.preventDefault();
+        removeTag(value.length - 1);
+      }
+    };
+
+    return (
+      <div
+        className={cn(
+          "flex flex-wrap gap-1.5 items-center min-h-10 w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm ring-offset-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring",
+          disabled && "opacity-50 pointer-events-none",
+          className,
+        )}
+        onClick={() => {
+          // Clicking chrome around the chips focuses the input — feels native
+          // without needing a separate label/for wiring.
+          const el = document.getElementById(id ?? "") as HTMLInputElement | null;
+          el?.focus();
+        }}
+      >
+        {value.map((tag, i) => (
+          <Badge key={`${tag}-${i}`} variant="secondary" className="gap-1">
+            {tag}
+            <button
+              type="button"
+              aria-label={`Remove ${tag}`}
+              className="rounded-sm hover:bg-muted-foreground/20 focus:outline-none focus:ring-1 focus:ring-ring"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeTag(i);
+              }}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+        <input
+          ref={ref}
+          id={id}
+          name={name}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          onBlur={() => addTag(draft)}
+          disabled={disabled}
+          placeholder={value.length === 0 ? placeholder : ""}
+          className="flex-1 min-w-[120px] bg-transparent outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+    );
+  },
+);
+TagInput.displayName = "TagInput";
+
+export { TagInput };

--- a/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/index.ts
+++ b/src/apps_generator/templates/builtin/ui_kit/files/__projectName__/src/index.ts
@@ -67,6 +67,8 @@ export { Calendar, type CalendarProps } from "./components/ui/calendar";
 export { DatePicker, type DatePickerProps } from "./components/ui/date-picker";
 export { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
 export { Combobox, type ComboboxProps, type ComboboxOption } from "./components/ui/combobox";
+export { MultiSelect, type MultiSelectProps, type MultiSelectOption } from "./components/ui/multi-select";
+export { TagInput, type TagInputProps } from "./components/ui/tag-input";
 export {
   Form, FormField, FormItem, FormLabel, FormControl,
   FormDescription, FormMessage, useFormField,

--- a/tests/test_array_field_types.py
+++ b/tests/test_array_field_types.py
@@ -1,0 +1,508 @@
+"""Tests for ``stringArray`` / ``enumArray`` field types + MultiSelect / TagInput.
+
+Covers three layers:
+
+1. **ui-kit** — ``MultiSelect`` and ``TagInput`` component files exist and
+   re-exported from the barrel ``index.ts``.
+2. **api-domain** — Java entity uses ``@ElementCollection`` + a
+   ``@CollectionTable`` join table; Liquibase migration emits the join
+   table + CASCADE FK; DTOs round-trip as plain ``List<...>``; TypeScript
+   types surface as ``string[]`` / ``(union)[]``.
+3. **frontend-app** — ``form`` / ``edit`` emitters render TagInput for
+   ``stringArray`` and MultiSelect for ``enumArray`` when ``--uikit`` is
+   linked, with plain-HTML fallback otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from apps_generator.cli.generators.linking import find_java_root, find_resources_root
+from apps_generator.cli.generators.pages import generate_page_components
+from apps_generator.cli.generators.resources import (
+    generate_resource_scaffolding,
+    parse_resources,
+)
+from apps_generator.cli.generators.types import generate_resource_types
+from apps_generator.core.generator import generate
+from apps_generator.templates.registry import resolve_template
+
+
+# ── ui-kit: MultiSelect + TagInput components ───────────────────────────────
+
+
+def test_ui_kit_ships_multi_select_component() -> None:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "src"
+        / "apps_generator"
+        / "templates"
+        / "builtin"
+        / "ui_kit"
+        / "files"
+        / "__projectName__"
+        / "src"
+        / "components"
+        / "ui"
+        / "multi-select.tsx"
+    )
+    assert path.exists()
+    content = path.read_text()
+    assert "export { MultiSelect }" in content
+    # MultiSelect composes Command + Popover + Badge — all three primitives
+    # are what makes it a "typeahead with selected chips" experience.
+    for sym in ["Command", "Popover", "Badge"]:
+        assert sym in content, f"multi-select.tsx missing import of {sym}"
+    # Value / onChange contract is an array
+    assert "value?: string[]" in content
+    assert "onChange?: (value: string[]) => void" in content
+
+
+def test_ui_kit_ships_tag_input_component() -> None:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "src"
+        / "apps_generator"
+        / "templates"
+        / "builtin"
+        / "ui_kit"
+        / "files"
+        / "__projectName__"
+        / "src"
+        / "components"
+        / "ui"
+        / "tag-input.tsx"
+    )
+    assert path.exists()
+    content = path.read_text()
+    assert "export { TagInput }" in content
+    # Enter + comma commit the draft; Backspace peels off the last tag —
+    # these are the keyboard semantics users expect from chip inputs.
+    assert '"Enter"' in content
+    assert '"Backspace"' in content
+
+
+def test_ui_kit_index_reexports_multi_select_and_tag_input() -> None:
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "src"
+        / "apps_generator"
+        / "templates"
+        / "builtin"
+        / "ui_kit"
+        / "files"
+        / "__projectName__"
+        / "src"
+        / "index.ts"
+    )
+    content = path.read_text()
+    assert "MultiSelect" in content
+    assert "MultiSelectOption" in content
+    assert "TagInput" in content
+
+
+# ── api-domain: Java entity ─────────────────────────────────────────────────
+
+
+def _generate_with_resources(tmp_path: Path, resources_json: str):
+    template = resolve_template("api-domain")
+    result = generate(
+        template_dir=template.path,
+        output_dir=tmp_path / "gen",
+        cli_values={
+            "projectName": "test-svc",
+            "groupId": "com.test",
+            "basePackage": "com.test.app",
+            "features.oauth2": "false",
+        },
+        interactive=False,
+    )
+    java_root = find_java_root(result, "test-svc", "com.test.app")
+    res_root = find_resources_root(result, "test-svc")
+    resources = parse_resources(resources_json)
+    generate_resource_scaffolding(java_root, res_root, resources, "com.test.app", "test-svc")
+    return java_root, res_root
+
+
+def test_string_array_entity_uses_element_collection(tmp_path: Path) -> None:
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "product",
+                    "fields": [
+                        {"name": "name", "type": "string"},
+                        {"name": "tags", "type": "stringArray"},
+                    ],
+                }
+            ]
+        ),
+    )
+    entity = (java_root / "domain" / "model" / "Product.java").read_text()
+    # Collection mapping — fetch eagerly so the DTO mapping sees the list
+    # without LazyInitializationException wobbles in the controller.
+    assert "@ElementCollection(fetch = FetchType.EAGER)" in entity
+    # Collection-table name + FK column spelled explicitly so schema and
+    # mapping can never drift.
+    assert '@CollectionTable(name = "products_tags"' in entity
+    assert '@JoinColumn(name = "product_id")' in entity
+    # Value column
+    assert '@Column(name = "tags")' in entity
+    # Default initializer so callers don't have to null-check
+    assert "private List<String> tags = new ArrayList<>()" in entity
+    # Required imports
+    assert "import java.util.List;" in entity
+    assert "import java.util.ArrayList;" in entity
+
+
+def test_enum_array_entity_uses_element_collection_plus_enumerated(tmp_path: Path) -> None:
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "post",
+                    "fields": [
+                        {"name": "title", "type": "string"},
+                        {
+                            "name": "channels",
+                            "type": "enumArray",
+                            "values": ["email", "sms", "push"],
+                        },
+                    ],
+                }
+            ]
+        ),
+    )
+    entity = (java_root / "domain" / "model" / "Post.java").read_text()
+    # Same ElementCollection shape...
+    assert "@ElementCollection(fetch = FetchType.EAGER)" in entity
+    assert '@CollectionTable(name = "posts_channels"' in entity
+    # ...plus @Enumerated so each row stores the enum's string name
+    assert "@Enumerated(EnumType.STRING)" in entity
+    # Typed as a List of the generated enum class (named after the field)
+    assert "private List<Channels> channels = new ArrayList<>()" in entity
+    # The enum class itself was generated
+    assert (java_root / "domain" / "model" / "Channels.java").exists()
+
+
+def test_array_fields_in_dto_are_plain_lists(tmp_path: Path) -> None:
+    """DTOs strip the JPA annotations — just a plain ``List<...>`` the
+    JSON deserializer can populate from a request array body."""
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "product",
+                    "fields": [
+                        {"name": "name", "type": "string"},
+                        {"name": "tags", "type": "stringArray"},
+                    ],
+                }
+            ]
+        ),
+    )
+    create = (java_root / "interfaces" / "rest" / "dto" / "CreateProductRequest.java").read_text()
+    patch = (java_root / "interfaces" / "rest" / "dto" / "PatchProductRequest.java").read_text()
+    resp = (java_root / "interfaces" / "rest" / "dto" / "ProductResponse.java").read_text()
+    for dto in (create, patch, resp):
+        assert "private List<String> tags;" in dto
+        # DTOs must NOT leak the entity-side JPA annotations
+        assert "@ElementCollection" not in dto
+        assert "@CollectionTable" not in dto
+
+
+def test_enum_array_dto_imports_generated_enum_class(tmp_path: Path) -> None:
+    """Enum classes live under ``{pkg}.domain.model`` — DTOs need the
+    explicit import or they fail to compile (same fix as the scalar
+    ``enum`` regression the suite already guards)."""
+    java_root, _ = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "post",
+                    "fields": [
+                        {
+                            "name": "channels",
+                            "type": "enumArray",
+                            "values": ["email", "sms"],
+                        }
+                    ],
+                }
+            ]
+        ),
+    )
+    for dto in ["CreatePostRequest", "UpdatePostRequest", "PatchPostRequest", "PostResponse"]:
+        content = (java_root / "interfaces" / "rest" / "dto" / f"{dto}.java").read_text()
+        assert "import com.test.app.domain.model.Channels;" in content
+        assert "private List<Channels> channels;" in content
+
+
+# ── api-domain: migration ───────────────────────────────────────────────────
+
+
+def test_string_array_migration_emits_join_table(tmp_path: Path) -> None:
+    _, res_root = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "product",
+                    "fields": [
+                        {"name": "name", "type": "string"},
+                        {"name": "tags", "type": "stringArray"},
+                    ],
+                }
+            ]
+        ),
+    )
+    changelog = yaml.safe_load((res_root / "db" / "changelog" / "changes" / "002-create-product.yaml").read_text())
+    changes = changelog["databaseChangeLog"][0]["changeSet"]["changes"]
+
+    # Main table: ``tags`` column must NOT appear — it lives in the join
+    # table, not on ``products``.
+    main_cols = changes[0]["createTable"]["columns"]
+    assert all(c["column"]["name"] != "tags" for c in main_cols)
+
+    # Join-table createTable
+    join_creates = [
+        c["createTable"] for c in changes if "createTable" in c and c["createTable"]["tableName"] == "products_tags"
+    ]
+    assert len(join_creates) == 1
+    join_cols = join_creates[0]["columns"]
+    assert any(c["column"]["name"] == "product_id" for c in join_cols)
+    assert any(c["column"]["name"] == "tags" for c in join_cols)
+
+    # FK with CASCADE so deleting the parent cleans up element rows
+    fks = [
+        c["addForeignKeyConstraint"]
+        for c in changes
+        if "addForeignKeyConstraint" in c and c["addForeignKeyConstraint"]["baseTableName"] == "products_tags"
+    ]
+    assert len(fks) == 1
+    assert fks[0]["onDelete"] == "CASCADE"
+    assert fks[0]["referencedTableName"] == "products"
+
+
+def test_enum_array_migration_sizes_column_from_longest_value(tmp_path: Path) -> None:
+    _, res_root = _generate_with_resources(
+        tmp_path,
+        json.dumps(
+            [
+                {
+                    "name": "post",
+                    "fields": [
+                        {
+                            "name": "channels",
+                            "type": "enumArray",
+                            "values": ["email", "push-notification"],
+                        }
+                    ],
+                }
+            ]
+        ),
+    )
+    changelog = yaml.safe_load((res_root / "db" / "changelog" / "changes" / "002-create-post.yaml").read_text())
+    changes = changelog["databaseChangeLog"][0]["changeSet"]["changes"]
+    join_create = next(
+        c["createTable"] for c in changes if "createTable" in c and c["createTable"]["tableName"] == "posts_channels"
+    )
+    value_col = next(c["column"] for c in join_create["columns"] if c["column"]["name"] == "channels")
+    # len("push-notification") == 17 → VARCHAR(17)
+    assert value_col["type"] == "VARCHAR(17)"
+
+
+# ── TypeScript types ────────────────────────────────────────────────────────
+
+
+def test_string_array_ts_type_is_array(tmp_path: Path) -> None:
+    src = tmp_path / "api-client" / "src"
+    src.mkdir(parents=True)
+    generate_resource_types(
+        src,
+        [
+            {
+                "name": "product",
+                "fields": [
+                    {"name": "name", "type": "string", "required": True},
+                    {"name": "tags", "type": "stringArray"},
+                ],
+            }
+        ],
+    )
+    ts = (src / "resources" / "product.ts").read_text()
+    # Response allows null; Create uses optional — same pattern as scalars
+    assert "tags: string[] | null;" in ts
+    assert "tags?: string[];" in ts
+
+
+def test_enum_array_ts_type_is_parenthesised_union_array(tmp_path: Path) -> None:
+    src = tmp_path / "api-client" / "src"
+    src.mkdir(parents=True)
+    generate_resource_types(
+        src,
+        [
+            {
+                "name": "post",
+                "fields": [
+                    {
+                        "name": "channels",
+                        "type": "enumArray",
+                        "values": ["email", "sms", "push"],
+                    }
+                ],
+            }
+        ],
+    )
+    ts = (src / "resources" / "post.ts").read_text()
+    # The union is parenthesised so ``[]`` binds to the whole thing — without
+    # that, TS parses ``"a" | "b"[]`` as ``"a" | ("b"[])``.
+    assert 'channels: ("email" | "sms" | "push")[] | null;' in ts
+
+
+# ── Form emitter: ui-kit branch ─────────────────────────────────────────────
+
+
+def _emit_form(tmp_path: Path, fields: list[dict], *, uikit: str = "my-ui") -> str:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    generate_page_components(
+        project_root=project_root,
+        pages=[
+            {
+                "path": "new",
+                "label": "New",
+                "resource": "product",
+                "type": "form",
+                "fields": fields,
+            }
+        ],
+        project_name="demo",
+        uikit_name=uikit,
+        api_client_name="my-api",
+    )
+    return (project_root / "src" / "routes" / "NewPage.tsx").read_text()
+
+
+def test_form_renders_string_array_as_tag_input_with_uikit(tmp_path: Path) -> None:
+    tsx = _emit_form(
+        tmp_path,
+        [
+            {"name": "name", "type": "string"},
+            {"name": "tags", "type": "stringArray"},
+        ],
+    )
+    # TagInput imported from ui-kit + wired with value / onChange
+    assert "TagInput" in tsx
+    assert "<TagInput" in tsx
+    assert "value={form.tags}" in tsx
+    # Form state default for arrays is [] not ""
+    assert "tags: [] as string[]" in tsx
+    # Body builder passes the array through (no Number cast, no || undefined)
+    assert "tags: form.tags," in tsx
+
+
+def test_form_renders_enum_array_as_multi_select_with_uikit(tmp_path: Path) -> None:
+    tsx = _emit_form(
+        tmp_path,
+        [
+            {"name": "title", "type": "string"},
+            {
+                "name": "channels",
+                "type": "enumArray",
+                "values": ["email", "sms", "push"],
+            },
+        ],
+    )
+    assert "MultiSelect" in tsx
+    assert "<MultiSelect" in tsx
+    # Options built from the field's ``values`` list — keyed by value, labelled
+    # with the title-cased enum name so display stays human-readable.
+    assert '{ value: "email", label: "Email" }' in tsx
+    assert '{ value: "sms", label: "Sms" }' in tsx
+    assert "channels: [] as string[]" in tsx
+
+
+# ── Form emitter: plain-HTML fallback ───────────────────────────────────────
+
+
+def test_form_plain_branch_uses_comma_input_for_string_array(tmp_path: Path) -> None:
+    """Without --uikit, there's no TagInput — fall back to a comma-separated
+    ``<input>``. Ugly but unambiguous and the form still submits an array."""
+    tsx = _emit_form(
+        tmp_path,
+        [
+            {"name": "tags", "type": "stringArray"},
+        ],
+        uikit="",
+    )
+    assert "TagInput" not in tsx
+    # Value is joined with ", " for display; on edit we split + trim + drop blanks
+    assert "form.tags.join(', ')" in tsx
+    assert ".split(',').map((s: string) => s.trim()).filter(Boolean)" in tsx
+
+
+def test_form_plain_branch_uses_multi_select_element_for_enum_array(tmp_path: Path) -> None:
+    tsx = _emit_form(
+        tmp_path,
+        [
+            {
+                "name": "channels",
+                "type": "enumArray",
+                "values": ["email", "sms"],
+            }
+        ],
+        uikit="",
+    )
+    assert "MultiSelect" not in tsx
+    # Native ``<select multiple>`` with Array.from(selectedOptions, ...)
+    assert "<select multiple" in tsx
+    assert "Array.from(e.target.selectedOptions" in tsx
+
+
+# ── Edit emitter: hydrate + body ────────────────────────────────────────────
+
+
+def test_edit_hydrates_array_fields_from_fetched_record(tmp_path: Path) -> None:
+    project_root = tmp_path / "app"
+    (project_root / "src" / "routes").mkdir(parents=True)
+    generate_page_components(
+        project_root=project_root,
+        pages=[
+            {
+                "path": "edit",
+                "label": "Edit Product",
+                "resource": "product",
+                "type": "edit",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "tags", "type": "stringArray"},
+                    {
+                        "name": "channels",
+                        "type": "enumArray",
+                        "values": ["email", "sms"],
+                    },
+                ],
+            }
+        ],
+        project_name="demo",
+        uikit_name="my-ui",
+        api_client_name="my-api",
+    )
+    tsx = (project_root / "src" / "routes" / "EditPage.tsx").read_text()
+    # Null-safe hydration — falls back to [] so the controlled widget never
+    # flips through ``undefined``.
+    assert "tags: data.tags ?? []," in tsx
+    assert "channels: data.channels ?? []," in tsx
+    # Both widgets imported and rendered
+    assert "TagInput" in tsx
+    assert "MultiSelect" in tsx
+    # PUT body passes arrays straight through
+    assert "tags: form.tags," in tsx
+    assert "channels: form.channels," in tsx


### PR DESCRIPTION
## Summary

Adds first-class multi-value fields to the generator, plus the two ui-kit components that make them pleasant to use in the generated forms.

- **Config** — opt in with `"type": "stringArray"` or `"type": "enumArray"` in the resource JSON.
- **Backend** — Hibernate `@ElementCollection` into a `{parent_table}_{field}` join table with a CASCADE FK; DTOs stay flat `List<...>`; Liquibase migration handles the join table, FK, index, and element-column sizing.
- **Frontend** — forms render a **TagInput** (chip input) for `stringArray` and a **MultiSelect** (typeahead with selected chips) for `enumArray` when `--uikit` is linked. Plain-HTML fallback uses a comma-separated `<input>` and a native `<select multiple>`.
- **ui-kit** — two new components: `multi-select.tsx` (Command + Popover + Badge) and `tag-input.tsx` (Input + Badge with Enter / comma / Backspace semantics).

## Example

```json
{
  "name": "post",
  "fields": [
    {"name": "title", "type": "string", "required": true},
    {"name": "tags", "type": "stringArray"},
    {"name": "channels", "type": "enumArray", "values": ["email", "sms", "push"]}
  ]
}
```

Generates:
- Entity: `private List<String> tags = new ArrayList<>();` + `@ElementCollection`, `@CollectionTable(name="posts_tags", joinColumns=@JoinColumn(name="post_id"))`, etc.
- TS: `tags: string[] | null;`, `channels: ("email" | "sms" | "push")[] | null;`
- Form page: `<TagInput>` for tags, `<MultiSelect>` for channels.

## Test plan

- [x] `pytest tests/` — 261 green (245 existing + 16 new)
- [x] `ruff format --check`, `mypy` clean (pre-existing yaml-stub errors only)
- [x] Generated `frontend-app` with form + edit over a resource carrying both a `stringArray` and an `enumArray` field → `npm run build` (vite) succeeds
- [ ] Follow-up: `settings` page type could pick up the same rendering; skipped here since singleton-with-array is rare.
